### PR TITLE
Use new Ruby 1.9 hash syntax for sha256 and depends_on

### DIFF
--- a/valgrind.rb
+++ b/valgrind.rb
@@ -7,12 +7,12 @@ class Valgrind < Formula
     mirror "https://dl.bintray.com/homebrew/mirror/valgrind-3.14.0.tar.bz2"
     sha256 "037c11bfefd477cc6e9ebe8f193bb237fe397f7ce791b4a4ce3fa1c6a520baa5"
 
-    depends_on :maximum_macos => :high_sierra
+    depends_on maximum_macos: :high_sierra
   end
 
   bottle do
-    sha256 "7869473ca1009d871dfcb496cc4d08e0318315d18721854ef42960b76e2ef64d" => :high_sierra
-    sha256 "5ac984d472025c7bbc081e3be88b31f709944cf924945ebe85427f00d7cca73e" => :sierra
+    sha256 high_sierra: "7869473ca1009d871dfcb496cc4d08e0318315d18721854ef42960b76e2ef64d"
+    sha256 sierra:      "5ac984d472025c7bbc081e3be88b31f709944cf924945ebe85427f00d7cca73e"
   end
 
   head do


### PR DESCRIPTION
These changes avoid the following warnings that appeared whenever the formula was read:

```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the louisbrunner/valgrind tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/louisbrunner/homebrew-valgrind/valgrind.rb:14

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the louisbrunner/valgrind tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/louisbrunner/homebrew-valgrind/valgrind.rb:15
  ```
  
  I simply run `brew style --fix` on the formula as suggested to fix it.