### PR TITLE
Update valgrind.rb

### DIFF
--- a/valgrind.rb
+++ b/valgrind.rb
@@ -16,7 +16,7 @@ class Valgrind < Formula
   end
 
   head do
-    url "https://github.com/LouisBrunner/valgrind-macos.git"
+    url "git://github.com/LouisBrunner/valgrind-macos.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
Fix the problem on MacOS 11.6, using Homebrew. It often fails to git clone the repository from LouisBrunner/valgrind-macos.git. By changing "https" to "git", the problem can be fixed.