### PR TITLE
Update README for potential Homebrew error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Then, install `valgrind`:
 brew install --HEAD LouisBrunner/valgrind/valgrind
 ```
 
+It is possible that Homebrew shows you the following error message afterwards:
+
+```bash
+error: Invalid usage: --HEAD is not supported with HOMEBREW_NO_INSTALL_FROM_API unset! To resolve please run:
+  export HOMEBREW_NO_INSTALL_FROM_API=1
+  brew tap Homebrew/core
+and retry this command.
+```
+
+If so, just execute both commands and retry the installation as mentioned above.
+
 You can now use `valgrind` as normal.
 
 Note: in case of failures during the build, [make sure you have the latest Xcode/CLI tools installed](https://github.com/LouisBrunner/valgrind-macos/issues/6#issuecomment-667587385).


### PR DESCRIPTION
On e.g. macOS Ventura 13.2, Homebrew throws an error when installing valgrind as mentioned in the README. However it also provides the solution for fixing it.

```bash
brew tap LouisBrunner/valgrind
brew install --HEAD LouisBrunner/valgrind/valgrind
(...)
error: Invalid usage: --HEAD is not supported with HOMEBREW_NO_INSTALL_FROM_API unset! To resolve please run:
  export HOMEBREW_NO_INSTALL_FROM_API=1
  brew tap Homebrew/core
and retry this command.
```

```bash
❯ sw_vers
ProductName:            macOS
ProductVersion:         13.2
BuildVersion:           22D49
❯ uname -a
Darwin xxxxxxxx 22.3.0 Darwin Kernel Version 22.3.0: Thu Jan  5 20:53:49 PST 2023; root:xnu-8792.81.2~2/RELEASE_X86_64 x86_64
```

After executing both commands, an installation is successful:

```bash
❯ export HOMEBREW_NO_INSTALL_FROM_API=1
❯ brew tap Homebrew/core                                                                                                                                        
Running `brew update --auto-update`...                                                                                                                          
==> Auto-updated Homebrew!                                                                                                                              
Updated 2 taps (homebrew/core and homebrew/cask).                                                                                                               
==> New Formulae                                                                                                                                                
cargo-make                 clang-build-analyzer       juicefs                    m1ddc                      qdmr                       xcdiff                   
cargo-release              crfsuite                   libaribcaption             opencl-clhpp-headers       tetra                                               
==> New Casks                                                                                                                                                   
capslocknodelay                 lotus                           pokemon-tcg-live                spotify4bigsur                  ulbow                           
copilot-for-xcode               monofocus                       rive                            spybuster                                                       

                                                                                                                                                           
❯ brew install --HEAD LouisBrunner/valgrind/valgrind                                                                                                            
==> Fetching louisbrunner/valgrind/valgrind                                                                                                                     
==> Cloning https://github.com/LouisBrunner/valgrind-macos.git                                                                                                  
Cloning into '/Users/dom/Library/Caches/Homebrew/valgrind--git'...                                                                                              
Updating files: 100% (6495/6495), done.                                                                                                                         
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
==> Installing valgrind from louisbrunner/valgrind
==> ./autogen.sh
==> ./configure --prefix=/usr/local/Cellar/valgrind/HEAD-4233f2e --enable-only64bit --build=amd64-darwin
==> make
==> make install
🍺  /usr/local/Cellar/valgrind/HEAD-4233f2e: 299 files, 33.0MB, built in 2 minutes 14 seconds
==> Running `brew cleanup valgrind`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/dom/Library/Caches/Homebrew/valgrind--3.20.0.tar.bz2... (15.7MB)
user=233.60s system=79.68s cpu=191% total=2:43.71
```