### PR TITLE
fix: (nearly) every warning

### DIFF
--- a/Makefile.all.am
+++ b/Makefile.all.am
@@ -256,7 +256,7 @@ AM_CCASFLAGS_AMD64_FREEBSD  = @FLAG_M64@ -g
 AM_FLAG_M3264_X86_DARWIN = -arch i386
 AM_CFLAGS_X86_DARWIN     = $(WERROR) -arch i386 $(AM_CFLAGS_BASE) \
         -I@XCODE_INC_DIR@ \
-				-mmacosx-version-min=10.6 \
+				-mmacosx-version-min=@DARWIN_MIN_SDK@ \
 				-fno-pic -fno-PIC
 
 AM_CFLAGS_PSO_X86_DARWIN = $(AM_CFLAGS_X86_DARWIN) $(AM_CFLAGS_PSO_BASE)
@@ -265,9 +265,10 @@ AM_CCASFLAGS_X86_DARWIN  = -arch i386 -g
 AM_FLAG_M3264_AMD64_DARWIN = -arch x86_64
 AM_CFLAGS_AMD64_DARWIN     = $(WERROR) -arch x86_64 $(AM_CFLAGS_BASE) \
           -I@XCODE_INC_DIR@ \
-			    -mmacosx-version-min=10.6
+			    -mmacosx-version-min=@DARWIN_MIN_SDK@
 AM_CFLAGS_PSO_AMD64_DARWIN = $(AM_CFLAGS_AMD64_DARWIN) $(AM_CFLAGS_PSO_BASE)
-AM_CCASFLAGS_AMD64_DARWIN  = -arch x86_64 -g
+AM_CCASFLAGS_AMD64_DARWIN  = -arch x86_64 -g \
+			    -mmacosx-version-min=@DARWIN_MIN_SDK@
 
 AM_FLAG_M3264_S390X_LINUX = @FLAG_M64@
 AM_CFLAGS_S390X_LINUX     = @FLAG_M64@ $(AM_CFLAGS_BASE) -fomit-frame-pointer

--- a/configure.ac
+++ b/configure.ac
@@ -50,9 +50,9 @@ CXXFLAGS="$CXXFLAGS"
 #----------------------------------------------------------------------------
 
 AC_PROG_LN_S
-m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
+m4_version_prereq([2.70], [AC_PROG_CC])
 # Make sure we can compile in C99 mode.
-if test "$ac_cv_prog_cc_c99" = "no"; then
+if test "$ac_prog_cc_stdc" = "c99"; then
     AC_MSG_ERROR([Valgrind relies on a C compiler supporting C99])
 fi
 AC_PROG_CPP
@@ -153,8 +153,8 @@ fi
 rm $tmpfile
 
 # Make sure we can compile in C99 mode.
-AC_PROG_CC_C99
-if test "$ac_cv_prog_cc_c99" = "no"; then
+AC_PROG_CC
+if test "$ac_prog_cc_stdc" = "c99"; then
     AC_MSG_ERROR([Valgrind relies on a C compiler supporting C99])
 fi
 
@@ -531,186 +531,191 @@ case "${host_os}" in
         ;;
 
      *darwin*)
-        AC_MSG_RESULT([ok (${host_os})])
-        VGCONF_OS="darwin"
-        AC_DEFINE([DARWIN_10_5], 100500, [DARWIN_VERS value for Mac OS X 10.5])
-        AC_DEFINE([DARWIN_10_6], 100600, [DARWIN_VERS value for Mac OS X 10.6])
-        AC_DEFINE([DARWIN_10_7], 100700, [DARWIN_VERS value for Mac OS X 10.7])
-        AC_DEFINE([DARWIN_10_8], 100800, [DARWIN_VERS value for Mac OS X 10.8])
-        AC_DEFINE([DARWIN_10_9], 100900, [DARWIN_VERS value for Mac OS X 10.9])
-        AC_DEFINE([DARWIN_10_10], 101000, [DARWIN_VERS value for Mac OS X 10.10])
-        AC_DEFINE([DARWIN_10_11], 101100, [DARWIN_VERS value for Mac OS X 10.11])
-        AC_DEFINE([DARWIN_10_12], 101200, [DARWIN_VERS value for macOS 10.12])
-        AC_DEFINE([DARWIN_10_13], 101300, [DARWIN_VERS value for macOS 10.13])
-        AC_DEFINE([DARWIN_10_14], 101400, [DARWIN_VERS value for macOS 10.14])
-        AC_DEFINE([DARWIN_10_15], 101500, [DARWIN_VERS value for macOS 10.15])
-        AC_DEFINE([DARWIN_11_00], 110000, [DARWIN_VERS value for macOS 11.0])
-        AC_DEFINE([DARWIN_12_00], 120000, [DARWIN_VERS value for macOS 12.0])
-        AC_DEFINE([DARWIN_13_00], 130000, [DARWIN_VERS value for macOS 13.0])
-        AC_DEFINE([DARWIN_14_00], 140000, [DARWIN_VERS value for macOS 14.0])
+      AC_MSG_RESULT([ok (${host_os})])
+      VGCONF_OS="darwin"
 
-        AC_DEFINE([XCODE_10_XX], 101400, [XCODE_VERS value for Xcode earlier than 10.15])
-        AC_DEFINE([XCODE_10_14_6], 101406, [XCODE_VERS value for Xcode 10.14.6])
-        AC_DEFINE([XCODE_10_15], 101500, [XCODE_VERS value for Xcode 10.15])
-        AC_DEFINE([XCODE_11_0], 110000, [XCODE_VERS value for Xcode 11.0])
-        AC_DEFINE([XCODE_12_0], 120000, [XCODE_VERS value for Xcode 12.0])
-        AC_DEFINE([XCODE_13_0], 130000, [XCODE_VERS value for Xcode 13.0])
-        AC_DEFINE([XCODE_14_0], 140000, [XCODE_VERS value for Xcode 14.0])
+      AC_DEFUN([AC_ADD_DARWIN_VERS],[
+        $1=$2
+        AC_DEFINE_UNQUOTED([$1], [$$1], [DARWIN_VERS value for $3])
+        AC_SUBST($1)
+      ])
+      AC_ADD_DARWIN_VERS(DARWIN_10_5, 100500, [Mac OS X 10.5])
+      AC_ADD_DARWIN_VERS(DARWIN_10_6, 100600, [Mac OS X 10.6])
+      AC_ADD_DARWIN_VERS(DARWIN_10_7, 100700, [Mac OS X 10.7])
+      AC_ADD_DARWIN_VERS(DARWIN_10_8, 100800, [Mac OS X 10.8])
+      AC_ADD_DARWIN_VERS(DARWIN_10_9, 100900, [Mac OS X 10.9])
+      AC_ADD_DARWIN_VERS(DARWIN_10_10, 101000, [Mac OS X 10.10])
+      AC_ADD_DARWIN_VERS(DARWIN_10_11, 101100, [Mac OS X 10.11])
+      AC_ADD_DARWIN_VERS(DARWIN_10_12, 101200, [macOS 10.12])
+      AC_ADD_DARWIN_VERS(DARWIN_10_13, 101300, [macOS 10.13])
+      AC_ADD_DARWIN_VERS(DARWIN_10_14, 101400, [macOS 10.14])
+      AC_ADD_DARWIN_VERS(DARWIN_10_15, 101500, [macOS 10.15])
+      AC_ADD_DARWIN_VERS(DARWIN_11_00, 110000, [macOS 11.0])
+      AC_ADD_DARWIN_VERS(DARWIN_12_00, 120000, [macOS 12.0])
+      AC_ADD_DARWIN_VERS(DARWIN_13_00, 130000, [macOS 13.0])
+      AC_ADD_DARWIN_VERS(DARWIN_14_00, 140000, [macOS 14.0])
 
-        # Substitute the Xcode include path detected earlier
-        AC_SUBST(XCODE_INC_DIR, [$xcodedir_inc])
+      AC_DEFINE([XCODE_10_XX], 101400, [XCODE_VERS value for Xcode earlier than 10.15])
+      AC_DEFINE([XCODE_10_14_6], 101406, [XCODE_VERS value for Xcode 10.14.6])
+      AC_DEFINE([XCODE_10_15], 101500, [XCODE_VERS value for Xcode 10.15])
+      AC_DEFINE([XCODE_11_0], 110000, [XCODE_VERS value for Xcode 11.0])
+      AC_DEFINE([XCODE_12_0], 120000, [XCODE_VERS value for Xcode 12.0])
+      AC_DEFINE([XCODE_13_0], 130000, [XCODE_VERS value for Xcode 13.0])
+      AC_DEFINE([XCODE_14_0], 140000, [XCODE_VERS value for Xcode 14.0])
 
-	AC_MSG_CHECKING([for the kernel version])
-	kernel=`uname -r`
+      # Substitute the Xcode include path detected earlier
+      AC_SUBST(XCODE_INC_DIR, [$xcodedir_inc])
 
-        # Nb: for Darwin we set DEFAULT_SUPP here.  That's because Darwin
-        # has only one relevant version, the OS version. The `uname` check
-        # is a good way to get that version (i.e. "Darwin 9.6.0" is Mac OS
-        # X 10.5.6, and "Darwin 10.x" is Mac OS X 10.6.x Snow Leopard,
-        # and possibly "Darwin 11.x" is Mac OS X 10.7.x Lion),
-        # and we don't know of an macros similar to __GLIBC__ to get that info.
-        #
-        # XXX: `uname -r` won't do the right thing for cross-compiles, but
-        # that's not a problem yet.
-        #
-        # jseward 21 Sept 2011: I seriously doubt whether V 3.7.0 will work
-        # on OS X 10.5.x; I haven't tested yet, and only plan to test 3.7.0
-        # on 10.6.8 and 10.7.1.  Although tempted to delete the configure
-        # time support for 10.5 (the 9.* pattern just below), I'll leave it
-        # in for now, just in case anybody wants to give it a try.  But I'm
-        # assuming that 3.7.0 is a Snow Leopard and Lion-only release.
-	case "${kernel}" in
-	     9.*)
-		  AC_MSG_RESULT([Darwin 9.x (${kernel}) / Mac OS X 10.5 Leopard])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_5, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin9.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin9-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     10.*)
-		  AC_MSG_RESULT([Darwin 10.x (${kernel}) / Mac OS X 10.6 Snow Leopard])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_6, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin10.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     11.*)
-		  AC_MSG_RESULT([Darwin 11.x (${kernel}) / Mac OS X 10.7 Lion])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_7, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin11.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     12.*)
-		  AC_MSG_RESULT([Darwin 12.x (${kernel}) / Mac OS X 10.8 Mountain Lion])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_8, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin12.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     13.*)
-		  AC_MSG_RESULT([Darwin 13.x (${kernel}) / Mac OS X 10.9 Mavericks])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_9, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin13.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     14.*)
-		  AC_MSG_RESULT([Darwin 14.x (${kernel}) / Mac OS X 10.10 Yosemite])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_10, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin14.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     15.*)
-		  AC_MSG_RESULT([Darwin 15.x (${kernel}) / Mac OS X 10.11 El Capitan])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_11, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin15.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     16.*)
-		  AC_MSG_RESULT([Darwin 16.x (${kernel}) / macOS 10.12 Sierra])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_12, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="$srcdir/darwin16.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-	     17.*)
-		  AC_MSG_RESULT([Darwin 17.x (${kernel}) / macOS 10.13 High Sierra])
-		  AC_DEFINE([DARWIN_VERS], DARWIN_10_13, [Darwin / Mac OS X version])
-		  DEFAULT_SUPP="$srcdir/darwin17.supp ${DEFAULT_SUPP}"
-		  DEFAULT_SUPP="$srcdir/darwin10-drd.supp ${DEFAULT_SUPP}"
-		  ;;
-             18.*)
-                  AC_MSG_RESULT([Darwin 18.x (${kernel}) / macOS 10.14 Mojave])
-                  AC_DEFINE([DARWIN_VERS], DARWIN_10_14, [Darwin / Mac OS X version])
-                  DEFAULT_SUPP="darwin18.supp ${DEFAULT_SUPP}"
-                  DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
+      AC_MSG_CHECKING([for the kernel version])
+      kernel=`uname -r`
+
+      # Nb: for Darwin we set DEFAULT_SUPP here.  That's because Darwin
+      # has only one relevant version, the OS version. The `uname` check
+      # is a good way to get that version (i.e. "Darwin 9.6.0" is Mac OS
+      # X 10.5.6, and "Darwin 10.x" is Mac OS X 10.6.x Snow Leopard,
+      # and possibly "Darwin 11.x" is Mac OS X 10.7.x Lion),
+      # and we don't know of an macros similar to __GLIBC__ to get that info.
+      #
+      # XXX: `uname -r` won't do the right thing for cross-compiles, but
+      # that's not a problem yet.
+      #
+      # jseward 21 Sept 2011: I seriously doubt whether V 3.7.0 will work
+      # on OS X 10.5.x; I haven't tested yet, and only plan to test 3.7.0
+      # on 10.6.8 and 10.7.1.  Although tempted to delete the configure
+      # time support for 10.5 (the 9.* pattern just below), I'll leave it
+      # in for now, just in case anybody wants to give it a try.  But I'm
+      # assuming that 3.7.0 is a Snow Leopard and Lion-only release.
+      DARWIN_DRD_SUPP="darwin10-drd.supp"
+      case "${kernel}" in
+        9.*)
+          AC_MSG_RESULT([Darwin 9.x (${kernel}) / Mac OS X 10.5 Leopard])
+          DARWIN_VERS=$DARWIN_10_5
+          DEFAULT_SUPP="$srcdir/darwin9.supp ${DEFAULT_SUPP}"
+          DARWIN_DRD_SUPP="darwin9-drd.supp"
+          ;;
+        10.*)
+          AC_MSG_RESULT([Darwin 10.x (${kernel}) / Mac OS X 10.6 Snow Leopard])
+          DARWIN_VERS=$DARWIN_10_6
+          DEFAULT_SUPP="$srcdir/darwin10.supp ${DEFAULT_SUPP}"
+          ;;
+        11.*)
+          AC_MSG_RESULT([Darwin 11.x (${kernel}) / Mac OS X 10.7 Lion])
+          DARWIN_VERS=$DARWIN_10_7
+          DEFAULT_SUPP="$srcdir/darwin11.supp ${DEFAULT_SUPP}"
+          ;;
+        12.*)
+          AC_MSG_RESULT([Darwin 12.x (${kernel}) / Mac OS X 10.8 Mountain Lion])
+          DARWIN_VERS=$DARWIN_10_8
+          DEFAULT_SUPP="$srcdir/darwin12.supp ${DEFAULT_SUPP}"
+          ;;
+        13.*)
+          AC_MSG_RESULT([Darwin 13.x (${kernel}) / Mac OS X 10.9 Mavericks])
+          DARWIN_VERS=$DARWIN_10_9
+          DEFAULT_SUPP="$srcdir/darwin13.supp ${DEFAULT_SUPP}"
+          ;;
+        14.*)
+          AC_MSG_RESULT([Darwin 14.x (${kernel}) / Mac OS X 10.10 Yosemite])
+          DARWIN_VERS=$DARWIN_10_10
+          DEFAULT_SUPP="$srcdir/darwin14.supp ${DEFAULT_SUPP}"
+          ;;
+        15.*)
+          AC_MSG_RESULT([Darwin 15.x (${kernel}) / Mac OS X 10.11 El Capitan])
+          DARWIN_VERS=$DARWIN_10_11
+          DEFAULT_SUPP="$srcdir/darwin15.supp ${DEFAULT_SUPP}"
+          ;;
+        16.*)
+          AC_MSG_RESULT([Darwin 16.x (${kernel}) / macOS 10.12 Sierra])
+          DARWIN_VERS=$DARWIN_10_12
+          DEFAULT_SUPP="$srcdir/darwin16.supp ${DEFAULT_SUPP}"
+          ;;
+        17.*)
+          AC_MSG_RESULT([Darwin 17.x (${kernel}) / macOS 10.13 High Sierra])
+          DARWIN_VERS=$DARWIN_10_13
+          DEFAULT_SUPP="$srcdir/darwin17.supp ${DEFAULT_SUPP}"
+          ;;
+        18.*)
+          AC_MSG_RESULT([Darwin 18.x (${kernel}) / macOS 10.14 Mojave])
+          DARWIN_VERS=$DARWIN_10_14
+          DEFAULT_SUPP="darwin18.supp ${DEFAULT_SUPP}"
+          ;;
+        19.*)
+          AC_MSG_RESULT([Darwin 19.x (${kernel}) / macOS 10.15 Catalina])
+          DARWIN_VERS=$DARWIN_10_15
+          DEFAULT_SUPP="darwin19.supp ${DEFAULT_SUPP}"
+          ;;
+        20.*)
+          AC_MSG_RESULT([Darwin 20.x (${kernel}) / macOS 11 Big Sur])
+          DARWIN_VERS=$DARWIN_11_00
+          DEFAULT_SUPP="darwin20.supp ${DEFAULT_SUPP}"
+          ;;
+        21.*)
+          AC_MSG_RESULT([Darwin 21.x (${kernel}) / macOS 12 Monterey])
+          DARWIN_VERS=$DARWIN_12_00
+          DEFAULT_SUPP="darwin21.supp ${DEFAULT_SUPP}"
+          ;;
+        22.*)
+          AC_MSG_RESULT([Darwin 22.x (${kernel}) / macOS 13 Ventura])
+          DARWIN_VERS=$DARWIN_13_00
+          DEFAULT_SUPP="darwin22.supp ${DEFAULT_SUPP}"
+          ;;
+        23.*)
+          AC_MSG_RESULT([Darwin 23.x (${kernel}) / macOS 14 Sonoma])
+          DARWIN_VERS=$DARWIN_14_00
+          DEFAULT_SUPP="darwin23.supp ${DEFAULT_SUPP}"
+          ;;
+        *)
+          AC_MSG_RESULT([unsupported (${kernel})])
+          AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-10.11 and macOS 10.12-14.0)])
+          ;;
+      esac
+      AC_DEFINE_UNQUOTED([DARWIN_VERS], $DARWIN_VERS, [Darwin / Mac OS X version])
+      AC_SUBST(DARWIN_VERS)
+      DEFAULT_SUPP="$srcdir/${DARWIN_DRD_SUPP} ${DEFAULT_SUPP}"
+
+      AC_MSG_CHECKING([for the the minimum macOS SDK version])
+      DARWIN_MIN_SDK="10.6"
+      if test $DARWIN_VERS -ge $DARWIN_11_00; then
+        DARWIN_MIN_SDK="10.8"
+      fi
+      AC_SUBST(DARWIN_MIN_SDK)
+      AC_DEFINE_UNQUOTED([DARWIN_MIN_SDK], $DARWIN_MIN_SDK, [Darwin / Mac OS X minimum SDK version])
+      AC_MSG_RESULT([${DARWIN_MIN_SDK}])
+
+      AC_MSG_CHECKING([for the Xcode SDK version])
+      xcodeversion="legacy"
+      if test "x$XCRUN" != "xno"; then
+        xcodeversion=`xcrun --sdk macosx --show-sdk-version`
+      fi
+      case "${xcodeversion}" in
+        10.14.6)
+          AC_DEFINE([XCODE_VERS], XCODE_10_14_6, [Xcode version])
+          ;;
+        legacy|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*|10.14*)
+          AC_DEFINE([XCODE_VERS], XCODE_10_XX, [Xcode version])
+          ;;
+        10.15*)
+          AC_DEFINE([XCODE_VERS], XCODE_10_15, [Xcode version])
+          ;;
+        11.*)
+          AC_DEFINE([XCODE_VERS], XCODE_11_0, [Xcode version])
+          ;;
+        12.*)
+          AC_DEFINE([XCODE_VERS], XCODE_12_0, [Xcode version])
+          ;;
+        13.*)
+          AC_DEFINE([XCODE_VERS], XCODE_13_0, [Xcode version])
+          ;;
+        14.*)
+          AC_DEFINE([XCODE_VERS], XCODE_14_0, [Xcode version])
+          ;;
+        *)
+          AC_MSG_RESULT([unsupported (${xcodeversion})])
+          AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-11 and macOS 10.12-14.0)])
+          ;;
+      esac
+      AC_MSG_RESULT([${xcodeversion}])
+
       ;;
-       19.*)
-      AC_MSG_RESULT([Darwin 19.x (${kernel}) / macOS 10.15 Catalina])
-      AC_DEFINE([DARWIN_VERS], DARWIN_10_15, [Darwin / Mac OS X version])
-      DEFAULT_SUPP="darwin19.supp ${DEFAULT_SUPP}"
-      DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
-                  ;;
-       20.*)
-      AC_MSG_RESULT([Darwin 20.x (${kernel}) / macOS 11 Big Sur])
-      AC_DEFINE([DARWIN_VERS], DARWIN_11_00, [Darwin / Mac OS X version])
-      DEFAULT_SUPP="darwin20.supp ${DEFAULT_SUPP}"
-      DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
-                  ;;
-       21.*)
-      AC_MSG_RESULT([Darwin 21.x (${kernel}) / macOS 12 Monterey])
-      AC_DEFINE([DARWIN_VERS], DARWIN_12_00, [Darwin / Mac OS X version])
-      DEFAULT_SUPP="darwin21.supp ${DEFAULT_SUPP}"
-      DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
-                  ;;
-       22.*)
-      AC_MSG_RESULT([Darwin 22.x (${kernel}) / macOS 13 Ventura])
-      AC_DEFINE([DARWIN_VERS], DARWIN_13_00, [Darwin / Mac OS X version])
-      DEFAULT_SUPP="darwin22.supp ${DEFAULT_SUPP}"
-      DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
-                  ;;
-       23.*)
-      AC_MSG_RESULT([Darwin 23.x (${kernel}) / macOS 14 Sonoma])
-      AC_DEFINE([DARWIN_VERS], DARWIN_14_00, [Darwin / Mac OS X version])
-      DEFAULT_SUPP="darwin23.supp ${DEFAULT_SUPP}"
-      DEFAULT_SUPP="darwin10-drd.supp ${DEFAULT_SUPP}"
-                  ;;
-             *)
-		  AC_MSG_RESULT([unsupported (${kernel})])
-		  AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-10.11 and macOS 10.12-14.0)])
-		  ;;
-	esac
-
-        AC_MSG_CHECKING([for the Xcode SDK version])
-        xcodeversion="legacy"
-        if test "x$XCRUN" != "xno"; then
-          xcodeversion=`xcrun --sdk macosx --show-sdk-version`
-        fi
-        case "${xcodeversion}" in
-	        10.14.6)
-            AC_DEFINE([XCODE_VERS], XCODE_10_14_6, [Xcode version])
-            ;;
-	        legacy|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*|10.14*)
-            AC_DEFINE([XCODE_VERS], XCODE_10_XX, [Xcode version])
-            ;;
-	        10.15*)
-            AC_DEFINE([XCODE_VERS], XCODE_10_15, [Xcode version])
-            ;;
-	        11.*)
-            AC_DEFINE([XCODE_VERS], XCODE_11_0, [Xcode version])
-            ;;
-	        12.*)
-            AC_DEFINE([XCODE_VERS], XCODE_12_0, [Xcode version])
-            ;;
-	        13.*)
-            AC_DEFINE([XCODE_VERS], XCODE_13_0, [Xcode version])
-            ;;
-          14.*)
-            AC_DEFINE([XCODE_VERS], XCODE_14_0, [Xcode version])
-            ;;
-	        *)
-            AC_MSG_RESULT([unsupported (${xcodeversion})])
-            AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-11 and macOS 10.12-14.0)])
-            ;;
-	      esac
-        AC_MSG_RESULT([${xcodeversion}])
-
-        ;;
 
      solaris2.11*)
         AC_MSG_RESULT([ok (${host_os})])

--- a/coregrind/Makefile.am
+++ b/coregrind/Makefile.am
@@ -569,9 +569,11 @@ endif
 # used by libgcc.
 #----------------------------------------------------------------------------
 
+if !COMPILER_IS_CLANG
 pkglib_LIBRARIES  += libgcc-sup-@VGCONF_ARCH_PRI@-@VGCONF_OS@.a
 if VGCONF_HAVE_PLATFORM_SEC
 pkglib_LIBRARIES += libgcc-sup-@VGCONF_ARCH_SEC@-@VGCONF_OS@.a
+endif
 endif
 
 libgcc_sup_@VGCONF_ARCH_PRI@_@VGCONF_OS@_a_SOURCES = \

--- a/coregrind/fixup_macho_loadcmds.c
+++ b/coregrind/fixup_macho_loadcmds.c
@@ -443,6 +443,10 @@ void modify_macho_loadcmds ( HChar* filename,
                if (DEBUGPRINTING)
                   printf("LC_UNIXTHREAD");
                break;
+            case LC_SOURCE_VERSION:
+               if (DEBUGPRINTING)
+                  printf("LC_SOURCE_VERSION");
+               break;
             default:
                if (DEBUGPRINTING)
                   printf("???");

--- a/coregrind/link_tool_exe_darwin.in
+++ b/coregrind/link_tool_exe_darwin.in
@@ -150,7 +150,12 @@ if ("$cc" =~ /clang$/) {
 }
 
 $cmd = "$cmd -arch $archstr";
-$cmd = "$cmd -macosx_version_min 10.6";
+if (@DARWIN_VERS@ < @DARWIN_11_00@) {
+  $cmd = "$cmd -macosx_version_min @DARWIN_MIN_SDK@";
+} else {
+  # they changed the name around 11.0
+  $cmd = "$cmd -macos_version_min @DARWIN_MIN_SDK@";
+}
 $cmd = "$cmd -o $outname";
 $cmd = "$cmd -u __start -e __start";
 
@@ -159,6 +164,7 @@ my $stack_addr_str = $stack_addr->as_hex();
 my $stack_size_str = Math::BigInt::as_hex($TX_STACK_SIZE);
 
 $cmd = "$cmd -image_base $ala";
+# FIXME: 14.0 and later, mark it as deprecated and ignored but it still works
 $cmd = "$cmd -stack_addr $stack_addr_str";
 $cmd = "$cmd -stack_size $stack_size_str";
 

--- a/coregrind/m_debuginfo/readdwarf3.c
+++ b/coregrind/m_debuginfo/readdwarf3.c
@@ -3118,7 +3118,6 @@ static void parse_var_DIE (
       UWord  typeR       = D3_INVALID_CUOFF;
       Bool   global      = False;
       GExpr* gexpr       = NULL;
-      Int    n_attrs     = 0;
       UWord  abs_ori     = (UWord)D3_INVALID_CUOFF;
       Int    lineNo      = 0;
       UInt   fndn_ix     = 0;
@@ -3130,7 +3129,6 @@ static void parse_var_DIE (
          nf_i++;
          if (attr == 0 && form == 0) break;
          get_Form_contents( &cts, cc, c_die, False/*td3*/, nf );
-         n_attrs++;
          if (attr == DW_AT_name && cts.szB < 0) {
             name = ML_(addStrFromCursor)( cc->di, cts.u.cur );
          }

--- a/coregrind/m_debuginfo/readpdb.c
+++ b/coregrind/m_debuginfo/readpdb.c
@@ -1536,7 +1536,6 @@ static ULong DEBUG_SnarfLinetab(
    Int                k;
    const UInt         * lt_ptr;
    Int                nfile;
-   Int                nseg;
    union any_size     pnt;
    union any_size     pnt2;
    const struct startend * start;
@@ -1560,10 +1559,8 @@ static ULong DEBUG_SnarfLinetab(
    /*
     * Now count up the number of segments in the file.
     */
-   nseg = 0;
    for (i = 0; i < nfile; i++) {
       pnt2.c = (const HChar *)linetab + filetab[i];
-      nseg += *pnt2.s;
    }
 
    this_seg = 0;

--- a/coregrind/m_initimg/initimg-darwin.c
+++ b/coregrind/m_initimg/initimg-darwin.c
@@ -73,6 +73,7 @@ static void load_client ( /*OUT*/ExeInfo* info,
 
    VG_(memset)(info, 0, sizeof(*info));
    ret = VG_(do_exec)(exe_name, info);
+   (void) ret;
 
    // The client was successfully loaded!  Continue.
 

--- a/coregrind/m_libcfile.c
+++ b/coregrind/m_libcfile.c
@@ -1420,6 +1420,7 @@ Int VG_(socket) ( Int domain, Int type, Int protocol )
                                VKI_SO_NOSIGPIPE, (UWord)&optval, 
                                sizeof(optval));
        // ignore setsockopt() error
+       (void) res2;
    }
    return sr_isError(res) ? -1 : sr_Res(res);
 

--- a/coregrind/m_mach/mach_msg.c
+++ b/coregrind/m_mach/mach_msg.c
@@ -123,17 +123,16 @@ mach_msg_options_after_interruption(mach_msg_option64_t option64)
 	return option64;
 }
 
-mach_msg_return_t
-mach_msg2(data, option64, msgh_bits_and_send_size, msgh_remote_and_local_port, msgh_voucher_and_id, desc_count_and_rcv_name, rcv_size_and_priority, timeout)
-    void *data;
-    mach_msg_option64_t option64;
-    uint64_t msgh_bits_and_send_size;
-    uint64_t msgh_remote_and_local_port;
-    uint64_t msgh_voucher_and_id;
-    uint64_t desc_count_and_rcv_name;
-    uint64_t rcv_size_and_priority;
-    uint64_t timeout;
-{
+mach_msg_return_t mach_msg2(
+  void *data,
+  mach_msg_option64_t option64,
+  uint64_t msgh_bits_and_send_size,
+  uint64_t msgh_remote_and_local_port,
+  uint64_t msgh_voucher_and_id,
+  uint64_t desc_count_and_rcv_name,
+  uint64_t rcv_size_and_priority,
+  uint64_t timeout
+) {
   mach_msg_return_t mr;
 
 	mr = mach_msg2_trap(data,
@@ -199,18 +198,7 @@ mach_msg_return_t mach_msg(
   mach_port_t rcv_name,
   mach_msg_timeout_t timeout,
   mach_port_t notify
-);
-
-mach_msg_return_t
-mach_msg(msg, option, send_size, rcv_size, rcv_name, timeout, notify)
-    mach_msg_header_t *msg;
-    mach_msg_option_t option;
-    mach_msg_size_t send_size;
-    mach_msg_size_t rcv_size;
-    mach_port_t rcv_name;
-    mach_msg_timeout_t timeout;
-    mach_port_t notify;
-{
+) {
 
 #if DARWIN_VERS >= DARWIN_13_00
     mach_msg_base_t *base;

--- a/coregrind/m_signals.c
+++ b/coregrind/m_signals.c
@@ -1668,6 +1668,8 @@ void VG_(kill_self)(Int sigNo)
 #  if !defined(VGO_darwin)
    /* This sometimes fails with EPERM on Darwin.  I don't know why. */
    vg_assert(r == 0);
+#  else
+   (void) r;
 #  endif
 
    VG_(convert_sigaction_fromK_to_toK)( &origsa, &origsa2 );


### PR DESCRIPTION
Resolves https://github.com/paulfloyd/macos_valgrind/issues/1

Only warning not fixed is `ld: warning: -stack_addr is deprecated, ignoring` which seems to be introduced in macOS 14.

Note that the warning is a misnomer as it might be deprecated but definitely not ignored (yet).