### PR TITLE
feat: add macOS 15 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains a version of Valgrind including a few patches to improv
 | macOS 12 (Monterey)         | -   | ✅    | ❌[^2] | -      |
 | macOS 13 (Ventura)          | -   | ✅    | ❌[^2] | -      |
 | macOS 14 (Sonoma)           | -   | ✅    | ❌[^2] | -      |
+| macOS 15 (Sequoia)          | -   | ✅    | ❌[^2] | -      |
 
 [^1]: Supported as part of upstream Valgrind.
 [^2]: Apple Silicon support in progress ([#56](https://github.com/LouisBrunner/valgrind-macos/issues/56))

--- a/configure.ac
+++ b/configure.ac
@@ -593,6 +593,7 @@ case "${host_os}" in
       AC_ADD_DARWIN_VERS(DARWIN_12_00, 120000, [macOS 12.0])
       AC_ADD_DARWIN_VERS(DARWIN_13_00, 130000, [macOS 13.0])
       AC_ADD_DARWIN_VERS(DARWIN_14_00, 140000, [macOS 14.0])
+      AC_ADD_DARWIN_VERS(DARWIN_15_00, 150000, [macOS 15.0])
 
       AC_DEFINE([XCODE_10_XX], 101400, [XCODE_VERS value for Xcode earlier than 10.15])
       AC_DEFINE([XCODE_10_14_6], 101406, [XCODE_VERS value for Xcode 10.14.6])
@@ -601,6 +602,7 @@ case "${host_os}" in
       AC_DEFINE([XCODE_12_0], 120000, [XCODE_VERS value for Xcode 12.0])
       AC_DEFINE([XCODE_13_0], 130000, [XCODE_VERS value for Xcode 13.0])
       AC_DEFINE([XCODE_14_0], 140000, [XCODE_VERS value for Xcode 14.0])
+      AC_DEFINE([XCODE_15_0], 150000, [XCODE_VERS value for Xcode 15.0])
 
       # Substitute the Xcode include path detected earlier
       AC_SUBST(XCODE_INC_DIR, [$xcodedir_inc])
@@ -702,9 +704,14 @@ case "${host_os}" in
           DARWIN_VERS=$DARWIN_14_00
           DEFAULT_SUPP="darwin23.supp ${DEFAULT_SUPP}"
           ;;
+        24.*)
+          AC_MSG_RESULT([Darwin 24.x (${kernel}) / macOS 15 Sequoia])
+          DARWIN_VERS=$DARWIN_15_00
+          DEFAULT_SUPP="darwin24.supp ${DEFAULT_SUPP}"
+          ;;
         *)
           AC_MSG_RESULT([unsupported (${kernel})])
-          AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-10.11 and macOS 10.12-14.0)])
+          AC_MSG_ERROR([Valgrind works on Darwin 10.x-24.x (Mac OS X 10.6-10.11 and macOS 10.12-15.0)])
           ;;
       esac
       AC_DEFINE_UNQUOTED([DARWIN_VERS], $DARWIN_VERS, [Darwin / Mac OS X version])
@@ -747,9 +754,12 @@ case "${host_os}" in
         14.*)
           AC_DEFINE([XCODE_VERS], XCODE_14_0, [Xcode version])
           ;;
+        15.*)
+          AC_DEFINE([XCODE_VERS], XCODE_15_0, [Xcode version])
+          ;;
         *)
           AC_MSG_RESULT([unsupported (${xcodeversion})])
-          AC_MSG_ERROR([Valgrind works on Darwin 10.x-23.x (Mac OS X 10.6-11 and macOS 10.12-14.0)])
+          AC_MSG_ERROR([Valgrind works on Darwin 10.x-24.x (Mac OS X 10.6-11 and macOS 10.12-15.0)])
           ;;
       esac
       AC_MSG_RESULT([${xcodeversion}])

--- a/coregrind/fixup_macho_loadcmds.c
+++ b/coregrind/fixup_macho_loadcmds.c
@@ -126,7 +126,7 @@
     && DARWIN_VERS != DARWIN_10_13 && DARWIN_VERS != DARWIN_10_14 \
     && DARWIN_VERS != DARWIN_10_15 && DARWIN_VERS != DARWIN_11_00 \
     && DARWIN_VERS != DARWIN_12_00 && DARWIN_VERS != DARWIN_13_00 \
-    && DARWIN_VERS != DARWIN_14_00
+    && DARWIN_VERS != DARWIN_14_00 && DARWIN_VERS != DARWIN_15_00
 #  error "Unknown DARWIN_VERS value.  This file only compiles on Darwin."
 #endif
 

--- a/coregrind/m_mach/dyld_cache.c
+++ b/coregrind/m_mach/dyld_cache.c
@@ -272,7 +272,7 @@ int VG_(dyld_cache_load_library)(const HChar* path) {
     return 0;
   }
 
-  VG_(debugLog)(2, "dyld_cache", "image is valid, forwarding to debuginfo: %s\n", path);
+  VG_(debugLog)(2, "dyld_cache", "image (%p) is valid, forwarding to debuginfo: %s\n", image, path);
   res = VG_(di_notify_dsc)(path, (Addr)image, len);
   if (res == 0) {
     VG_(debugLog)(2, "dyld_cache", "failed to load debuginfo from: %s\n", path);

--- a/coregrind/m_replacemalloc/vg_replace_malloc.c
+++ b/coregrind/m_replacemalloc/vg_replace_malloc.c
@@ -454,6 +454,10 @@ extern int * __error(void) __attribute__((weak));
  ALLOC_or_NULL(SO_SYN_MALLOC,         malloc,      malloc);
  ZONEALLOC_or_NULL(VG_Z_LIBC_SONAME,  malloc_zone_malloc, malloc);
  ZONEALLOC_or_NULL(SO_SYN_MALLOC,     malloc_zone_malloc, malloc);
+#if DARWIN_VERS >= DARWIN_15_00
+ ALLOC_or_NULL(VG_Z_LIBC_SONAME,     malloc_type_malloc,      malloc);
+ ZONEALLOC_or_NULL(VG_Z_LIBC_SONAME, malloc_type_zone_malloc, malloc);
+#endif
 
 #elif defined(VGO_solaris)
  ALLOC_or_NULL(VG_Z_LIBSTDCXX_SONAME, malloc,      malloc);
@@ -997,6 +1001,10 @@ extern int * __error(void) __attribute__((weak));
  FREE(SO_SYN_MALLOC,          free,                 free );
  ZONEFREE(VG_Z_LIBC_SONAME,   malloc_zone_free,     free );
  ZONEFREE(SO_SYN_MALLOC,      malloc_zone_free,     free );
+#if DARWIN_VERS >= DARWIN_15_00
+ FREE(VG_Z_LIBC_SONAME,     malloc_type_free,      free);
+ ZONEFREE(VG_Z_LIBC_SONAME, malloc_type_zone_free, free);
+#endif
 
 #elif defined(VGO_solaris)
  FREE(VG_Z_LIBC_SONAME,       free,                 free );
@@ -1683,6 +1691,10 @@ extern int * __error(void) __attribute__((weak));
  CALLOC(SO_SYN_MALLOC,    calloc);
  ZONECALLOC(VG_Z_LIBC_SONAME, malloc_zone_calloc);
  ZONECALLOC(SO_SYN_MALLOC,    malloc_zone_calloc);
+#if DARWIN_VERS >= DARWIN_15_00
+ CALLOC(VG_Z_LIBC_SONAME,     malloc_type_calloc);
+ ZONECALLOC(VG_Z_LIBC_SONAME, malloc_type_zone_calloc);
+#endif
 
 #elif defined(VGO_solaris)
  CALLOC(VG_Z_LIBC_SONAME,      calloc);
@@ -1816,6 +1828,10 @@ extern int * __error(void) __attribute__((weak));
  REALLOCF(SO_SYN_MALLOC, reallocf);
  ZONEREALLOC(VG_Z_LIBC_SONAME, malloc_zone_realloc);
  ZONEREALLOC(SO_SYN_MALLOC,    malloc_zone_realloc);
+#if DARWIN_VERS >= DARWIN_15_00
+ REALLOC(VG_Z_LIBC_SONAME,     malloc_type_realloc);
+ ZONEREALLOC(VG_Z_LIBC_SONAME, malloc_type_zone_realloc);
+#endif
 
 #elif defined(VGO_solaris)
  REALLOC(VG_Z_LIBC_SONAME,      realloc);
@@ -2022,6 +2038,10 @@ extern int * __error(void) __attribute__((weak));
 #elif defined(VGO_darwin)
  ZONEMEMALIGN(VG_Z_LIBC_SONAME, malloc_zone_memalign);
  ZONEMEMALIGN(SO_SYN_MALLOC,    malloc_zone_memalign);
+#if DARWIN_VERS >= DARWIN_15_00
+ MEMALIGN(VG_Z_LIBC_SONAME,     malloc_type_aligned_alloc);
+ ZONEMEMALIGN(VG_Z_LIBC_SONAME, malloc_type_zone_memalign);
+#endif
 
 #elif defined(VGO_solaris)
  MEMALIGN(VG_Z_LIBC_SONAME,      memalign);
@@ -2080,6 +2100,10 @@ extern int * __error(void) __attribute__((weak));
  VALLOC(SO_SYN_MALLOC, valloc);
  ZONEVALLOC(VG_Z_LIBC_SONAME, malloc_zone_valloc);
  ZONEVALLOC(SO_SYN_MALLOC,    malloc_zone_valloc);
+#if DARWIN_VERS >= DARWIN_15_00
+ VALLOC(VG_Z_LIBC_SONAME,     malloc_type_valloc);
+ ZONEVALLOC(VG_Z_LIBC_SONAME, malloc_type_zone_valloc);
+#endif
 
 #elif defined(VGO_solaris)
  VALLOC(VG_Z_LIBC_SONAME,      valloc);
@@ -2222,6 +2246,9 @@ extern int * __error(void) __attribute__((weak));
 #elif defined(VGO_darwin)
 #if (DARWIN_VERSIO >= DARWIN_10_6)
  POSIX_MEMALIGN(VG_Z_LIBC_SONAME, posix_memalign);
+#endif
+#if DARWIN_VERS >= DARWIN_15_00
+ POSIX_MEMALIGN(VG_Z_LIBC_SONAME, malloc_type_posix_memalign);
 #endif
 
 #elif defined(VGO_solaris)
@@ -2648,6 +2675,104 @@ ZONE_GET_NAME(VG_Z_LIBC_SONAME, malloc_get_zone_name);
 ZONE_GET_NAME(SO_SYN_MALLOC,    malloc_get_zone_name);
 
 #endif /* defined(VGO_darwin) */
+
+
+/*------------------ Darwin malloc_with_options ------------------*/
+
+#if defined(VGO_darwin) && DARWIN_VERS >= DARWIN_15_00
+
+#define WITH_OPTIONS_INIT_FLAG 1
+
+static void* malloc_with_options(const HChar* name, void* zone, SizeT alignment, SizeT size, UWord flags, void* reserved1, void* reserved2, Bool type_mode)
+{
+  void* v;
+  SizeT orig_alignment = alignment;
+  struct AlignedAllocInfo aligned_alloc_info = {
+    .orig_alignment = alignment,
+    .size           = size,
+    .alloc_kind     = AllocKindPosixMemalign
+  };
+
+  DO_INIT;
+  if (alignment != 0) {
+    VERIFY_ALIGNMENT(&aligned_alloc_info);
+  }
+  TRIGGER_MEMCHECK_ERROR_IF_UNDEFINED((UWord) zone);
+  TRIGGER_MEMCHECK_ERROR_IF_UNDEFINED(alignment);
+  TRIGGER_MEMCHECK_ERROR_IF_UNDEFINED(size);
+  TRIGGER_MEMCHECK_ERROR_IF_UNDEFINED(flags);
+  MALLOC_TRACE("%s(%p, al %llu, sz %llu, fl %lx, ?1 %p, ?2 %p)", name, zone, (ULong)alignment, (ULong)size, flags, reserved1, reserved2);
+
+  if (type_mode && flags == 0) {
+    flags = WITH_OPTIONS_INIT_FLAG;
+  }
+
+  if (alignment != 0) {
+    if (alignment % sizeof(void*) != 0 ||
+        (alignment & (alignment - 1)) != 0) {
+        SET_ERRNO_EINVAL;
+        return NULL;
+    }
+
+    /* Round up to minimum alignment if necessary. */
+    if (alignment < VG_MIN_MALLOC_SZB)
+        alignment = VG_MIN_MALLOC_SZB;
+
+    /* Round up to nearest power-of-two if necessary (like glibc). */
+    while (0 != (alignment & (alignment - 1)))
+        alignment++;
+  }
+
+  if (alignment != 0) {
+    v = (void*)VALGRIND_NON_SIMD_CALL3(info.tl_memalign, alignment, orig_alignment, size );
+    if (v != 0 && (flags & WITH_OPTIONS_INIT_FLAG) != 0x0) {
+      // FIXME: would be better to use `VG_(memset)(v, 0, size);` no?
+      for (SizeT i = 0; i < size; i += 1) {
+        ((UChar*)v)[i] = 0;
+      }
+    }
+  } else {
+    if ((flags & WITH_OPTIONS_INIT_FLAG) == 0) {
+      v = (void*)VALGRIND_NON_SIMD_CALL1(info.tl_malloc, size);
+    } else {
+      v = (void*)VALGRIND_NON_SIMD_CALL2(info.tl_calloc, 0x1, size);
+    }
+  }
+  MALLOC_TRACE(" = %p\n", v);
+  if (!v) SET_ERRNO_ENOMEM;
+  return v;
+}
+
+// Technically _np is the one which is flipped but it avoid an another swap in the helper function this way.
+#define WITH_OPTIONS_INTERNAL(soname, fnname) \
+  \
+  const void* VG_REPLACE_FUNCTION_EZU(10300,soname,fnname)(void* zone, SizeT alignment, SizeT size, void* reserved1, UWord flags, void* reserved2); \
+  const void* VG_REPLACE_FUNCTION_EZU(10300,soname,fnname)(void* zone, SizeT alignment, SizeT size, void* reserved1, UWord flags, void* reserved2)  \
+  { \
+    return malloc_with_options(#fnname, zone, alignment, size, flags, reserved1, reserved2, True); \
+  }
+
+#define WITH_OPTIONS_NP(soname, fnname) \
+  \
+  const void* VG_REPLACE_FUNCTION_EZU(10301,soname,fnname)(void* zone, SizeT alignment, SizeT size, UWord flags, void* reserved1, void* reserved2); \
+  const void* VG_REPLACE_FUNCTION_EZU(10301,soname,fnname)(void* zone, SizeT alignment, SizeT size, UWord flags, void* reserved1, void* reserved2)  \
+  { \
+    return malloc_with_options(#fnname, zone, alignment, size, flags, reserved1, reserved2, True); \
+  }
+
+#define WITH_OPTIONS(soname, fnname) \
+  \
+  const void* VG_REPLACE_FUNCTION_EZU(10302,soname,fnname)(void* zone, SizeT alignment, SizeT size, UWord flags, void* reserved1, void* reserved2); \
+  const void* VG_REPLACE_FUNCTION_EZU(10302,soname,fnname)(void* zone, SizeT alignment, SizeT size, UWord flags, void* reserved1, void* reserved2)  \
+  { \
+      return malloc_with_options(#fnname, zone, alignment, size, flags, reserved1, reserved2, False); \
+  }
+
+
+WITH_OPTIONS_NP(VG_Z_LIBC_SONAME, malloc_type_zone_malloc_with_options_np);
+WITH_OPTIONS_INTERNAL(VG_Z_LIBC_SONAME, malloc_type_zone_malloc_with_options_internal);
+WITH_OPTIONS(VG_Z_LIBC_SONAME, malloc_zone_malloc_with_options_np);
+#endif /* defined(VGO_darwin) && DARWIN_VERS >= DARWIN_15_00 */
 
 
 /*------------------ (startup related) ------------------*/

--- a/coregrind/m_syswrap/syswrap-amd64-darwin.c
+++ b/coregrind/m_syswrap/syswrap-amd64-darwin.c
@@ -490,7 +490,8 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
             || DARWIN_VERS == DARWIN_11_00 \
             || DARWIN_VERS == DARWIN_12_00 \
             || DARWIN_VERS == DARWIN_13_00 \
-            || DARWIN_VERS == DARWIN_14_00
+            || DARWIN_VERS == DARWIN_14_00 \
+            || DARWIN_VERS == DARWIN_15_00
        UWord magic_delta = 0xE0;
 #      else
 #        error "magic_delta: to be computed on new OS version"

--- a/darwin24.supp
+++ b/darwin24.supp
@@ -12,6 +12,7 @@
    ...
 }
 
+# Related to DSC and other dyld memory access
 
 {
    OSX1500:dyld_validMagic
@@ -48,6 +49,8 @@
    fun:(below main)
 }
 
+# New in 15.0
+
 {
    OSX1500:dyld_CRC32cSW
    Memcheck:Value8
@@ -77,12 +80,172 @@
 }
 
 {
-   OSX1500:libSystem_clock_port
+   OSX1500:libc_clock_port
    Memcheck:Cond
    obj:*
    fun:_init_clock_port
    fun:_libc_initializer
    fun:libSystem_initializer
    fun:___ZNK5dyld46Loader25findAndRunAllInitializersERNS_12RuntimeStateE_block_invoke
+   ...
+}
+
+{
+   OSX1500:libxpc_init
+   Memcheck:Cond
+   obj:*
+   fun:_libxpc_initializer
+   fun:libSystem_initializer
+   fun:___ZNK5dyld46Loader25findAndRunAllInitializersERNS_12RuntimeStateE_block_invoke
+   ...
+}
+
+{
+   OSX:libsecinit_fetch_self_token
+   Memcheck:Cond
+   fun:_fetch_self_token
+   ...
+   fun:_libsecinit_initializer
+   fun:libSystem_initializer
+   fun:___ZNK5dyld46Loader25findAndRunAllInitializersERNS_12RuntimeStateE_block_invoke
+   ...
+}
+
+{
+   OSX1500:libtrace_create_debug_control_port
+   Memcheck:Cond
+   obj:*
+   fun:_os_trace_create_debug_control_port
+   fun:_libtrace_init
+   fun:libSystem_initializer
+   fun:___ZNK5dyld46Loader25findAndRunAllInitializersERNS_12RuntimeStateE_block_invoke
+   ...
+}
+
+# Happens during a fork
+
+{
+   OSX1500:fork_xpc_cond
+   Memcheck:Cond
+   ...
+   fun:bootstrap_look_up2
+   ...
+}
+
+{
+   OSX1500:fork_xpc_addr16
+   Memcheck:Addr16
+   ...
+   fun:bootstrap_look_up2
+   ...
+}
+
+{
+   OSX1500:ns_initialize_platform_cond
+   Memcheck:Cond
+   ...
+   fun:_NSInitializePlatform
+   ...
+}
+
+{
+   OSX1500:ns_initialize_platform_value8
+   Memcheck:Value8
+   obj:*
+   ...
+   fun:_NSInitializePlatform
+   ...
+}
+
+{
+   OSX1500:ns_initialize_platform_param
+   Memcheck:Param
+   open(filename)
+   obj:*
+   obj:*
+   ...
+   fun:_NSInitializePlatform
+   ...
+}
+
+# Unclear, most likely because of fork
+
+{
+   OSX1500:notify_register_check
+   Memcheck:Cond
+   ...
+   fun:notify_register_check
+   ...
+   fun:si_module_config_modules_for_category
+   ...
+}
+
+{
+   OSX1500:getpwuid_r_addr16
+   Memcheck:Addr16
+   obj:*
+   ...
+   fun:search_user_byuid
+   fun:getpwuid_r
+}
+
+{
+   OSX1500:getpwuid_r_value8
+   Memcheck:Value8
+   obj:*
+   ...
+   fun:search_user_byuid
+   ...
+}
+
+{
+   OSX1500:getpwuid_r_cond
+   Memcheck:Cond
+   ...
+   fun:search_user_byuid
+}
+
+{
+   OSX1500:getpwuid_r_cond_2
+   Memcheck:Cond
+   obj:*
+   obj:*
+   ...
+   fun:ds_user_byuid
+}
+
+{
+   OSX1500:getpwuid_r_value8_2
+   Memcheck:Value8
+   obj:*
+   ...
+   fun:ds_user_byuid
+}
+
+{
+   OSX1500:firehose_param_mach_msg2_1
+   Memcheck:Param
+   mach_msg2(msgh_bits_and_send_size)
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   fun:firehose_drain_notifications_once
+   ...
+   fun:___ZN5dyld44APIs33_dyld_register_func_for_add_imageEPFvPK11mach_headerlE_block_invoke
+   ...
+}
+
+{
+   OSX1500:firehose_param_mach_msg2_1
+   Memcheck:Param
+   mach_msg2(msgh_voucher_and_id)
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   fun:firehose_drain_notifications_once
+   ...
+   fun:___ZN5dyld44APIs33_dyld_register_func_for_add_imageEPFvPK11mach_headerlE_block_invoke
    ...
 }

--- a/darwin24.supp
+++ b/darwin24.supp
@@ -1,0 +1,88 @@
+
+# Suppressions for Darwin 24.x / macOS 15.0 Sequoia
+
+############################################
+
+# I don't understand how chkstk works so no clue how to properly handle it
+
+{
+   OSX1500:chkstk
+   Memcheck:Addr1
+   fun:__chkstk_darwin_probe
+   ...
+}
+
+
+{
+   OSX1500:dyld_validMagic
+   Memcheck:Cond
+   fun:_ZN5dyld3L10validMagicERKNS_18SharedCacheOptionsEPK15DyldSharedCache
+   ...
+   fun:(below main)
+}
+
+{
+   OSX1500:dyld_checksOSBinary
+   Memcheck:Value8
+   fun:_ZNK5dyld311GradedArchs14checksOSBinaryEv
+   ...
+   fun:_ZN5dyld4L7prepareERNS_4APIsEPKN5dyld313MachOAnalyzerE
+}
+
+{
+   OSX1500:dyld_GradedArchs_grade
+   Memcheck:Value8
+   fun:_ZNK5dyld311GradedArchs5gradeEjjb
+   ...
+   fun:___ZN5dyld4L7prepareERNS_4APIsEPKN5dyld313MachOAnalyzerE_block_invoke
+}
+
+{
+   OSX1500:dyld_FileRecord_stat64
+   Memcheck:Param
+   stat64(path)
+   fun:stat$INODE64
+   fun:_ZNK5dyld410FileRecord4statEv
+   ...
+   fun:_ZZN5dyld45startEPNS_10KernelArgsEPvS2_ENK3$_0clEv
+   fun:(below main)
+}
+
+{
+   OSX1500:dyld_CRC32cSW
+   Memcheck:Value8
+   fun:_ZN3lsl8CRC32cSW8checksumEjNSt3__14spanISt4byteLm18446744073709551615EEE
+   ...
+   fun:_ZZN5dyld45startEPNS_10KernelArgsEPvS2_ENK3$_0clEv
+   fun:(below main)
+}
+
+{
+   OSX1500:dyld_CRC32cSW_2
+   Memcheck:Value8
+   fun:_ZN3lsl8CRC32cSW8checksumEjNSt3__14spanISt4byteLm18446744073709551615EEE
+   ...
+   fun:_ZN5dyld4L7prepareERNS_4APIsEPKN5dyld313MachOAnalyzerE
+}
+
+{
+   OSX1500:dyld_setUpPageInLinkingRegions_map_with_linking
+   Memcheck:Param
+   map_with_linking_np(link_info)
+   fun:__map_with_linking_np
+   fun:_ZN5dyld4L25setUpPageInLinkingRegionsERNS_12RuntimeStateEPKNS_6LoaderEmttbRKN5dyld35ArrayINS_18PageInLinkingRangeEEERKNS6_IPKvEE
+   ...
+   fun:_ZZN5dyld45startEPNS_10KernelArgsEPvS2_ENK3$_0clEv
+   fun:(below main)
+}
+
+{
+   OSX1500:libSystem_clock_port
+   Memcheck:Cond
+   obj:*
+   fun:_init_clock_port
+   fun:_libc_initializer
+   fun:libSystem_initializer
+   fun:___ZNK5dyld46Loader25findAndRunAllInitializersERNS_12RuntimeStateE_block_invoke
+   ...
+}

--- a/include/vki/vki-scnums-darwin.h
+++ b/include/vki/vki-scnums-darwin.h
@@ -927,6 +927,8 @@
 #define __NR_MAXSYSCALL             VG_DARWIN_SYSCALL_CONSTRUCT_UNIX(555)
 #elif DARWIN_VERS == DARWIN_14_00
 #define __NR_MAXSYSCALL             VG_DARWIN_SYSCALL_CONSTRUCT_UNIX(555)
+#elif DARWIN_VERS == DARWIN_15_00
+#define __NR_MAXSYSCALL             VG_DARWIN_SYSCALL_CONSTRUCT_UNIX(555) // TODO: invalid
 #else
 #error unknown darwin version
 #endif


### PR DESCRIPTION
Resolves #109 

Changes:

* Usual changes to `configure.ac`, suppressions, etc
* Add redir for some new functions in `libsystem_malloc.so` (`malloc_type_XYZ` and `malloc_zone_malloc_with_options_np`)

Note: due to XNU sources not being available, I kept the syscalls max number to the same as 14.0.