### PR TITLE
fix(13.0): exclude __DATA_CONST as well during macho reading

### DIFF
--- a/.github/flaky-tests.txt
+++ b/.github/flaky-tests.txt
@@ -9,3 +9,4 @@ memcheck/tests/sem
 none/tests/sem
 # seen on macOS 14
 memcheck/tests/leak-cases-summary
+memcheck/tests/arm64/bug484935

--- a/coregrind/m_debuginfo/readmacho.c
+++ b/coregrind/m_debuginfo/readmacho.c
@@ -92,8 +92,8 @@ static Int count_rw_loads(const struct load_command* macho_load_commands, unsign
       if (lc->cmd == LC_SEGMENT_CMD) {
         const struct SEGMENT_COMMAND* sc = (const struct SEGMENT_COMMAND*)lc;
         if (sc->initprot == 3
-#if DARWIN_VERS >= DARWIN_14_00
-// FIXME: somehow __DATA_CONST appears as rw- in most binaries in macOS 14 and later (not sure when that started)
+#if DARWIN_VERS >= DARWIN_13_00
+// FIXME: somehow __DATA_CONST appears as rw- in most binaries in macOS 13 and later (not sure when that started)
 // so we ignore it otherwise some binaries don't get symbols
             && VG_(strcmp)(sc->segname, "__DATA_CONST") != 0
 #endif


### PR DESCRIPTION
Resolves #108 