### PR TITLE
feat(amd64): add signal support + wqthread for 15.0

### DIFF
--- a/coregrind/m_syswrap/syscall-amd64-darwin.S
+++ b/coregrind/m_syswrap/syscall-amd64-darwin.S
@@ -89,7 +89,6 @@
 	pushq	%rsi  // -16(%rbp)  guest_state
 	pushq	%rdx  // -24(%rbp)  sysmask
 	pushq	%rcx  // -32(%rbp)  postmask
-	pushq	%r8   // -40(%rbp)  sigsetSzB
 	// stack is now aligned
 	
 L_$0_1:	/* Even though we can't take a signal until the sigprocmask completes,
@@ -97,18 +96,13 @@ L_$0_1:	/* Even though we can't take a signal until the sigprocmask completes,
 	   If rip is in the range [1,2), the syscall hasn't been started yet */
 
 	/* Set the signal mask which should be current during the syscall. */
-	/* GrP fixme signals
-           DDD: JRS fixme: use __NR___pthread_sigmask, not __NR_rt_sigprocmask
-	movq	$__NR_rt_sigprocmask, %rax	// syscall #
-	movq	$VKI_SIG_SETMASK, %rdi		// how
+	movq	$$__NR___pthread_sigmask, %rax	// syscall #
+	movq	$$VKI_SIG_SETMASK, %rdi		// how
 	movq	-24(%rbp), %rsi			// sysmask
 	movq	-32(%rbp), %rdx			// postmask
-	movq	-40(%rbp), %r10			// sigsetSzB in r10 not rcx
-	DDD: fixme return address
 	syscall
 
-	jnc	7f	// sigprocmask failed
-	*/
+	jc	L_$0_7	// sigprocmask failed
 	
 	/* OK, that worked.  Now do the syscall proper. */
 
@@ -153,45 +147,36 @@ L_$0_3:	/* In the range [3, 4), the syscall result is in %rax,
 	movq	%rax, %rdi	/* arg1 = new flag */
 	movq	%r11, %rsi	/* arg2 = vex state */
 	addq	$$24, %rsp	/* remove syscall parameters */
-        movl    $$1, OFFSET_amd64_SETC(%r11)
+	movl	$$1, OFFSET_amd64_SETC(%r11)
 	call	_LibVEX_GuestAMD64_put_rflag_c
-        movq	-16(%rbp), %r11
-        movl    $$0, OFFSET_amd64_SETC(%r11)
+	movq	-16(%rbp), %r11
+	movl	$$0, OFFSET_amd64_SETC(%r11)
 .else
 	addq	$$24, %rsp	/* remove syscall parameters*/
 .endif
 
 L_$0_4:	/* Re-block signals.  If eip is in [4,5), then the syscall 
 	   is complete and we needn't worry about it. */
-	/* GrP fixme signals
-           DDD: JRS fixme: use __NR___pthread_sigmask, not __NR_rt_sigprocmask
-	PUSH_di_si_dx_cx_8
-
-	movq	$__NR_rt_sigprocmask, %rax	// syscall #
-	movq	$VKI_SIG_SETMASK, %rdi		// how
-	movq	%rcx, %rsi			// postmask
+	movq	$$__NR___pthread_sigmask, %rax	// syscall #
+	movq	$$VKI_SIG_SETMASK, %rdi		// how
+	movq	-32(%rbp), %rsi			// postmask
 	xorq	%rdx, %rdx			// NULL
-	movq	%r8, %r10			// sigsetSzB
-	DDD: fixme return address
 	syscall
 
-	POP_di_si_dx_cx_8
+	jc	L_$0_7	// sigprocmask failed
 
-	jnc	7f	// sigprocmask failed
-	*/
 L_$0_5:	/* now safe from signals */
 	movq	$$0, %rax	/* SUCCESS */
 	movq	%rbp, %rsp
 	popq	%rbp
 	ret
 
-/* GrP fixme signals
 L_$0_7:	// failure:	 return 0x8000 | error code
-	DDD: fixme return value
+	andq	$$0x7FFF, %rax
+	orq	$$0x8000, %rax
 	movq	%rbp, %rsp
 	popq	%rbp
 	ret
-*/
 
 .endmacro
 

--- a/coregrind/m_syswrap/syscall-arm64-darwin.S
+++ b/coregrind/m_syswrap/syscall-arm64-darwin.S
@@ -68,7 +68,7 @@
               void* guest_state,             // x1
               const vki_sigset_t *sysmask,   // x2
               const vki_sigset_t *postmask,  // x3
-              Int nsigwords)                 // x4
+              Int nsigwords)                 // x4 (ignored)
 */
 
 /* from vki_arch.h */
@@ -89,7 +89,6 @@
    stp  x23, x24, [sp, #-16]!
    stp  x21, x22, [sp, #-16]!
    stp  x19, x20, [sp, #-16]!
-   stp  x4,  x5,  [sp, #-16]!
    stp  x2,  x3,  [sp, #-16]!
    stp  x0,  x1,  [sp, #-16]!
 
@@ -98,15 +97,14 @@ L_$0_1:	/* Even though we can't take a signal until the sigprocmask completes,
 	   If rip is in the range [1,2), the syscall hasn't been started yet */
 
 	/* Set the signal mask which should be current during the syscall. */
-  ldr x16, =__NR_sigprocmask
+  ldr x16, =__NR___pthread_sigmask
   ldr x0, =VKI_SIG_SETMASK
   mov x1, x2 // sysmask
   mov x2, x3 // postmask
-  mov x3, x4 // nsigwords
   svc 0x80
 
   cmp x0, #0
-  blt 7f
+  blt L_$0_7
 
 	/* OK, that worked.  Now do the syscall proper. */
 
@@ -141,27 +139,25 @@ L_$0_3:	/* In the range [3, 4), the syscall result is in %rax,
 .if $0 == UNIX
 	/* save carry flag to VEX */
   mov x0, x4       /* arg1 = new flag */
-  ldr x1, [sp, #8] /* arg2 = vex state */
+  mov x1, x5       /* arg2 = vex state */
 	bl	_LibVEX_GuestARM64_put_nzcv_c
 .endif
 
 L_$0_4:	/* Re-block signals.  If eip is in [4,5), then the syscall
 	   is complete and we needn't worry about it. */
-  ldr x16, =__NR_sigprocmask
+  ldr x16, =__NR___pthread_sigmask
   ldr x0, =VKI_SIG_SETMASK
   ldr x1, [sp, #24] // saved x3 == postmask
   mov x2, #0
-  ldr x3, [sp, #32] // saved x4 == nsigwords
   svc 0x80
 
   cmp x0, #0
-  blt 7f
+  blt L_$0_7
 
 L_$0_5:	/* now safe from signals */
   mov  x0, #0
   ldp  xzr, x1,  [sp], #16
   ldp  x2,  x3,  [sp], #16
-  ldp  x4,  x5,  [sp], #16
   ldp  x19, x20, [sp], #16
   ldp  x21, x22, [sp], #16
   ldp  x23, x24, [sp], #16
@@ -170,11 +166,10 @@ L_$0_5:	/* now safe from signals */
   ldp  x29, x30, [sp], #16
   ret
 
-7: /* Failure: return 0x8000 | error code */
+L_$0_7: /* Failure: return 0x8000 | error code */
   orr  x0, x0, #0x8000
   ldp  xzr, x1,  [sp], #16
   ldp  x2,  x3,  [sp], #16
-  ldp  x4,  x5,  [sp], #16
   ldp  x19, x20, [sp], #16
   ldp  x21, x22, [sp], #16
   ldp  x23, x24, [sp], #16

--- a/coregrind/m_syswrap/syswrap-amd64-darwin.c
+++ b/coregrind/m_syswrap/syswrap-amd64-darwin.c
@@ -451,8 +451,8 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
 
    if (0) VG_(printf)(
              "wqthread_hijack: self %#lx, kport %#lx, "
-	     "stackaddr %#lx, workitem %#lx, reuse/flags %x, sp %#lx\n",
-	     self, kport, stackaddr, workitem, (UInt)reuse, sp);
+	     "stackaddr %#lx, workitem %#lx, reuse/flags %#x, kevent_count %d, sp %#lx\n",
+	     self, kport, stackaddr, workitem, (UInt)reuse, kevent_count, sp);
 
    /* Start the thread with all signals blocked.  VG_(scheduler) will
       set the mask correctly when we finally get there. */
@@ -476,7 +476,7 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
      /* For whatever reason, tst->os_state.pthread appear to have a
         constant offset of 96 on 10.7, but zero on 10.6 and 10.5.  No
         idea why. */
-#      if DARWIN_VERS <= DARWIN_10_6
+#      if DARWIN_VERS <= DARWIN_10_6 || DARWIN_VERS >= DARWIN_15_00
        UWord magic_delta = 0;
 #      elif DARWIN_VERS == DARWIN_10_7 || DARWIN_VERS == DARWIN_10_8
        UWord magic_delta = 0x60;
@@ -490,8 +490,7 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
             || DARWIN_VERS == DARWIN_11_00 \
             || DARWIN_VERS == DARWIN_12_00 \
             || DARWIN_VERS == DARWIN_13_00 \
-            || DARWIN_VERS == DARWIN_14_00 \
-            || DARWIN_VERS == DARWIN_15_00
+            || DARWIN_VERS == DARWIN_14_00
        UWord magic_delta = 0xE0;
 #      else
 #        error "magic_delta: to be computed on new OS version"
@@ -514,6 +513,10 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
                           tid, (void *)tst, tst->os_state.pthread, self);
 
        vex = &tst->arch.vex;
+       if (tst->os_state.pthread - magic_delta != self) {
+         VG_(printf)("wqthread_hijack reuse: tst->os_state.pthread %#lx vs self %#lx (diff: %#lx vs %#lx)\n",
+                     tst->os_state.pthread, self, tst->os_state.pthread - self, magic_delta);
+       }
        vg_assert(tst->os_state.pthread - magic_delta == self);
    }
    else {

--- a/coregrind/m_syswrap/syswrap-arm64-darwin.c
+++ b/coregrind/m_syswrap/syswrap-arm64-darwin.c
@@ -525,6 +525,10 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr kevent_list,
                           tid, (void *)tst, tst->os_state.pthread, self);
 
        vex = &tst->arch.vex;
+       if (tst->os_state.pthread - magic_delta != self) {
+         VG_(printf)("wqthread_hijack reuse: tst->os_state.pthread %#lx vs self %#lx (diff: %#lx vs %#lx)\n",
+                     tst->os_state.pthread, self, tst->os_state.pthread - self, magic_delta);
+       }
        vg_assert(tst->os_state.pthread - magic_delta == self);
    }
    else {

--- a/coregrind/m_syswrap/syswrap-darwin.c
+++ b/coregrind/m_syswrap/syswrap-darwin.c
@@ -994,9 +994,19 @@ void update_syncstats ( CheckHowOften cho,
    // reorder
    static UInt reorder_ctr = 0;
    if (i > 0 && 0 == (1 & reorder_ctr++)) {
+#if defined(VGA_amd64)
+      // Some kind of compiler xmm-based optimization which causes a EXC_I386_GPFLT
+      // happens on amd64 on later macOS versions (seen on 15.0).
+      // Instead we do a boring memcpy.
+      SyncStats tmp;
+      VG_(memcpy)(&tmp, &syncstats[i-1], sizeof(SyncStats));
+      VG_(memcpy)(&syncstats[i-1], &syncstats[i], sizeof(SyncStats));
+      VG_(memcpy)(&syncstats[i], &tmp, sizeof(SyncStats));
+#else
       SyncStats tmp = syncstats[i-1];
       syncstats[i-1] = syncstats[i];
       syncstats[i] = tmp;
+#endif
    }
 }
 

--- a/coregrind/m_syswrap/syswrap-x86-darwin.c
+++ b/coregrind/m_syswrap/syswrap-x86-darwin.c
@@ -397,8 +397,8 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
 
    if (0) VG_(printf)(
              "wqthread_hijack: self %#lx, kport %#lx, "
-             "stackaddr %#lx, workitem %#lx, reuse/flags %x, sp %#lx\n",
-             self, kport, stackaddr, workitem, reuse, sp);
+             "stackaddr %#lx, workitem %#lx, reuse/flags %x, kevent_count %d, sp %#lx\n",
+             self, kport, stackaddr, workitem, reuse, kevent_count, sp);
 
    /* Start the thread with all signals blocked.  VG_(scheduler) will
       set the mask correctly when we finally get there. */
@@ -454,6 +454,10 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr workitem,
                          tid, tst, tst->os_state.pthread, self);
 
       vex = &tst->arch.vex;
+      if (tst->os_state.pthread - magic_delta != self) {
+        VG_(printf)("wqthread_hijack reuse: tst->os_state.pthread %#lx vs self %#lx (diff: %#lx vs %#lx)\n",
+                    tst->os_state.pthread, self, tst->os_state.pthread - self, magic_delta);
+      }
       vg_assert(tst->os_state.pthread - magic_delta == self);
    }
    else {


### PR DESCRIPTION
Resolves #4 on latest macOS versions and part of #117

Changes:

 * Display expected magic delta before crashing (so it's easier for users to report their values on other versions)
 * Re-add the amd64 signals blocking during syscalls
 * Clean up the arm64 syscall assembly and use `__NR___pthread_sigmask` as suggested for amd64
 * Adapt magic_delta for macOS 15 amd64