### PR TITLE
fix(amd64): properly load libsystem_* in macOS 11+

### DIFF
--- a/coregrind/m_initimg/initimg-darwin.c
+++ b/coregrind/m_initimg/initimg-darwin.c
@@ -677,6 +677,7 @@ IIFinaliseImageInfo VG_(ii_create_image)( IICreateImageInfo iicii,
        setup_client_stack( iicii.argv - 1, env, &info,
                            iicii.clstack_end, iifii.clstack_max_size,
                            vex_archinfo );
+   iifii.dynamic = info.dynamic;
 
    VG_(free)(env);
 

--- a/coregrind/m_mach/dyld_cache.c
+++ b/coregrind/m_mach/dyld_cache.c
@@ -209,7 +209,7 @@ Addr VG_(dyld_cache_get_slide)(void) {
   return dyld_cache.slide;
 }
 
-void VG_(dyld_cache_init)(Bool is_dynamic) {
+void VG_(dyld_cache_init)(void) {
   if (!try_to_init()) {
     VG_(dmsg)(
       "WARNING: could not read from dyld shared cache (DSC)\n"
@@ -217,14 +217,12 @@ void VG_(dyld_cache_init)(Bool is_dynamic) {
     );
     return;
   }
-  if (is_dynamic) {
-    // We currently detect if dyld is loading/using a library by checking if stat64 fails.
-    // However, dyld doesn't seem to call stat64 for all of them anymore.
-    // All arm64 binaries are executables but some x86 ones might not be so let's avoid them just to be safe.
-    VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_kernel.dylib");
-    VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_pthread.dylib");
-    VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_platform.dylib");
-  }
+  // We currently detect if dyld is loading/using a library by checking if stat64 fails.
+  // However, dyld doesn't seem to call stat64 for all of them anymore.
+  // All arm64 binaries are executables but some x86 ones might not be so let's avoid them just to be safe.
+  VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_kernel.dylib");
+  VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_pthread.dylib");
+  VG_(dyld_cache_load_library)("/usr/lib/system/libsystem_platform.dylib");
 }
 
 int VG_(dyld_cache_might_be_in)(const HChar* path) {

--- a/coregrind/m_main.c
+++ b/coregrind/m_main.c
@@ -1976,7 +1976,9 @@ Int valgrind_main ( Int argc, HChar **argv, HChar **envp )
    //   p: none
    //--------------------------------------------------------------
 #  if defined(VGO_darwin) && DARWIN_VERS >= DARWIN_11_00
-   VG_(dyld_cache_init)(the_iicii.dynamic);
+   if (the_iifii.dynamic) {
+     VG_(dyld_cache_init)();
+   }
 #  endif
 
    //--------------------------------------------------------------

--- a/coregrind/m_main.c
+++ b/coregrind/m_main.c
@@ -1976,7 +1976,7 @@ Int valgrind_main ( Int argc, HChar **argv, HChar **envp )
    //   p: none
    //--------------------------------------------------------------
 #  if defined(VGO_darwin) && DARWIN_VERS >= DARWIN_11_00
-   VG_(dyld_cache_init)();
+   VG_(dyld_cache_init)(the_iicii.dynamic);
 #  endif
 
    //--------------------------------------------------------------

--- a/coregrind/pub_core_initimg.h
+++ b/coregrind/pub_core_initimg.h
@@ -48,7 +48,7 @@ typedef  struct _IIFinaliseImageInfo  IIFinaliseImageInfo;
    To do this it takes a bundle of information in an IICreateImageInfo
    structure, which is gathered in an OS-specific way at startup.
    This returns an IIFinaliseImageInfo structure: */
-extern 
+extern
 IIFinaliseImageInfo VG_(ii_create_image)( IICreateImageInfo,
                                           const VexArchInfo* vex_archinfo );
 
@@ -57,7 +57,7 @@ IIFinaliseImageInfo VG_(ii_create_image)( IICreateImageInfo,
    guest state for thread 1 (the root thread) and copy in essential
    starting values.  This is handed the IIFinaliseImageInfo created by
    VG_(ii_create_image). */
-extern 
+extern
 void VG_(ii_finalise_image)( IIFinaliseImageInfo );
 
 /* Note that both IICreateImageInfo and IIFinaliseImageInfo are
@@ -107,7 +107,6 @@ struct _IICreateImageInfo {
    Addr    stack_start;      /* stack segment hot */
    Addr    stack_end;        /* stack segment cold */
    Addr    text;             /* executable's Mach header */
-   Bool    dynamic;          /* False iff executable is static */
    HChar*  executable_path;  /* path passed to execve() */
 };
 
@@ -117,6 +116,7 @@ struct _IIFinaliseImageInfo {
    Addr  initial_client_SP;
    /* ------ Per-OS fields ------ */
    Addr  initial_client_IP;
+   Bool  dynamic;  /* False iff executable is static */
 };
 
 /* ------------------------- Solaris ------------------------- */

--- a/coregrind/pub_core_mach.h
+++ b/coregrind/pub_core_mach.h
@@ -72,7 +72,7 @@ extern void VG_(mach_record_system_memory)(void);
 #if DARWIN_VERS >= DARWIN_11_00
 // Dyld shared cache (DSC) parsing, which is required as system libraries are not provided on disk
 // starting with macOS 11.0 (Big Sur)
-extern void VG_(dyld_cache_init)(Bool is_dynamic);
+extern void VG_(dyld_cache_init)(void);
 extern int VG_(dyld_cache_might_be_in)(const HChar*);
 extern int VG_(dyld_cache_load_library)(const HChar*);
 extern Addr VG_(dyld_cache_get_slide)(void);

--- a/coregrind/pub_core_mach.h
+++ b/coregrind/pub_core_mach.h
@@ -72,7 +72,7 @@ extern void VG_(mach_record_system_memory)(void);
 #if DARWIN_VERS >= DARWIN_11_00
 // Dyld shared cache (DSC) parsing, which is required as system libraries are not provided on disk
 // starting with macOS 11.0 (Big Sur)
-extern void VG_(dyld_cache_init)(void);
+extern void VG_(dyld_cache_init)(Bool is_dynamic);
 extern int VG_(dyld_cache_might_be_in)(const HChar*);
 extern int VG_(dyld_cache_load_library)(const HChar*);
 extern Addr VG_(dyld_cache_get_slide)(void);

--- a/memcheck/tests/wcpncpy.stderr.exp
+++ b/memcheck/tests/wcpncpy.stderr.exp
@@ -1,19 +1,19 @@
 Conditional jump or move depends on uninitialised value(s)
-   at 0x........: wcpncpy (vg_replace_strmem.c:2584)
+   at 0x........: wcpncpy (vg_replace_strmem.c:2605)
    by 0x........: main (wcpncpy.c:14)
 
 Invalid write of size 4
-   at 0x........: wcpncpy (vg_replace_strmem.c:2584)
+   at 0x........: wcpncpy (vg_replace_strmem.c:2605)
    by 0x........: main (wcpncpy.c:27)
  Address 0x........ is 20 bytes inside a block of size 22 alloc'd
    at 0x........: malloc (vg_replace_malloc.c:...)
    by 0x........: main (wcpncpy.c:10)
 
 Source and destination overlap in wcpncpy(0x........, 0x........)
-   at 0x........: wcpncpy (vg_replace_strmem.c:2584)
+   at 0x........: wcpncpy (vg_replace_strmem.c:2605)
    by 0x........: main (wcpncpy.c:35)
 
 Source and destination overlap in wcpncpy(0x........, 0x........)
-   at 0x........: wcpncpy (vg_replace_strmem.c:2584)
+   at 0x........: wcpncpy (vg_replace_strmem.c:2605)
    by 0x........: main (wcpncpy.c:43)
 

--- a/shared/vg_replace_strmem.c
+++ b/shared/vg_replace_strmem.c
@@ -1054,22 +1054,26 @@ static inline void my_exit ( int x )
 # if defined(VGP_arm64_darwin)
   MEMCHR(libsystemZuplatformZddylib, _platform_memchr)
 # else
-# if DARWIN_VERS == DARWIN_10_9
+#  if DARWIN_VERS == DARWIN_10_9
   MEMCHR(VG_Z_DYLD,                   memchr)
   MEMCHR(libsystemZuplatformZddylib, _platform_memchr)
-# endif
-# if DARWIN_VERS >= DARWIN_10_10
+#  endif
+#  if DARWIN_VERS >= DARWIN_10_10
   MEMCHR(VG_Z_DYLD,                   memchr)
   /* _platform_memchr$VARIANT$Generic */
   MEMCHR(libsystemZuplatformZddylib, _platform_memchr$VARIANT$Generic)
   /* _platform_memchr$VARIANT$Haswell */
   MEMCHR(libsystemZuplatformZddylib, _platform_memchr$VARIANT$Haswell)
-# endif
-# if DARWIN_VERS >= DARWIN_10_12
+#  endif
+#  if DARWIN_VERS >= DARWIN_10_12
   /* _platform_memchr$VARIANT$Base */
   MEMCHR(libsystemZuplatformZddylib, _platform_memchr$VARIANT$Base)
-#endif
-#endif
+#  endif
+// FIXME: unsure of the exact version
+#  if DARWIN_VERS >= DARWIN_13_00
+  MEMCHR(libsystemZuplatformZddylib, _platform_memchr$VARIANT$NoOverread)
+#  endif
+# endif
 
 #elif defined(VGO_solaris)
  MEMCHR(VG_Z_LIBC_SONAME, memchr)
@@ -1305,7 +1309,11 @@ static inline void my_exit ( int x )
  MEMCMP(VG_Z_LIBC_SONAME,  timingsafe_bcmp)
 
 #elif defined(VGO_darwin)
-# if DARWIN_VERS >= DARWIN_10_9
+// FIXME: unsure of the exact version
+# if DARWIN_VERS >= DARWIN_13_00 && defined(VGA_amd64)
+  MEMCMP(libsystemZuplatformZddylib, _platform_memcmp$VARIANT$Base)
+  MEMCMP(libsystemZuplatformZddylib, _platform_memcmp$VARIANT$NoOverread)
+# elif DARWIN_VERS >= DARWIN_10_9
   MEMCMP(libsystemZuplatformZddylib, _platform_memcmp)
 # endif
 
@@ -1475,6 +1483,13 @@ static inline void my_exit ( int x )
   MEMSET(libsystemZucZddylib, __memset_chk)
   MEMSET(libsystemZuplatformZddylib, memset)
   MEMSET(libsystemZuplatformZddylib, _platform_memset)
+# else
+// FIXME: unsure of the exact version
+#  if DARWIN_VERS >= DARWIN_13_00
+  MEMSET(libsystemZuplatformZddylib, _platform_memset$VARIANT$Base)
+  MEMSET(libsystemZuplatformZddylib, _platform_memset$VARIANT$Haswell)
+  MEMSET(libsystemZuplatformZddylib, _platform_memset$VARIANT$Ivybridge)
+#  endif
 # endif
 
 #elif defined(VGO_solaris)
@@ -1505,15 +1520,21 @@ static inline void my_exit ( int x )
 # if defined(VGP_arm64_darwin)
   MEMMOVE(libsystemZuplatformZddylib, _platform_memmove)
 # else
-# if DARWIN_VERS <= DARWIN_10_6
+#  if DARWIN_VERS <= DARWIN_10_6
   MEMMOVE(VG_Z_LIBC_SONAME, memmove)
-# endif
+#  endif
  MEMMOVE(VG_Z_LIBC_SONAME,  memmoveZDVARIANTZDsse3x) /* memmove$VARIANT$sse3x */
  MEMMOVE(VG_Z_LIBC_SONAME,  memmoveZDVARIANTZDsse42) /* memmove$VARIANT$sse42 */
-# if DARWIN_VERS >= DARWIN_10_9
+#  if DARWIN_VERS >= DARWIN_10_9
   /* _platform_memmove$VARIANT$Ivybridge */
   MEMMOVE(libsystemZuplatformZddylib, ZuplatformZumemmoveZDVARIANTZDIvybridge)
-# endif
+#  endif
+// FIXME: unsure of the exact version
+#  if DARWIN_VERS >= DARWIN_13_00
+  MEMMOVE(libsystemZuplatformZddylib, ZuplatformZumemmoveZDVARIANTZDBase)
+  MEMMOVE(libsystemZuplatformZddylib, ZuplatformZumemmoveZDVARIANTZDHaswell)
+  MEMMOVE(libsystemZuplatformZddylib, ZuplatformZumemmoveZDVARIANTZDNehalem)
+#  endif
 # endif
 
 #elif defined(VGO_solaris)


### PR DESCRIPTION
Resolves #135 

Issue seems the same as on arm64: some libsystem_ are not loaded, so symbols aren't loaded and their redirs aren't processed.