### PR TITLE
Enforce C-style comment

### DIFF
--- a/include/valgrind.h.in
+++ b/include/valgrind.h.in
@@ -4377,7 +4377,7 @@ typedef
 
 #if defined(PLAT_arm64_linux) || defined(PLAT_arm64_freebsd) || defined(PLAT_arm64_darwin)
 
-// x18 is reserved by Apple and cannot be used (lots of warnings otherwise)
+/* x18 is reserved by Apple and cannot be used (lots of warnings otherwise) */
 #if defined(PLAT_arm64_darwin)
 #define __CALLER_SAVED_REGS_SPECIAL
 #else


### PR DESCRIPTION
Otherwise, C89 code, such as [libsecp256k1](https://github.com/bitcoin-core/secp256k1), will fail to build.