### PR TITLE
Add more dyld-related suppressions for macOS 15 amd64

### DIFF
--- a/darwin24-amd64.supp
+++ b/darwin24-amd64.supp
@@ -122,6 +122,34 @@
    ...
 }
 
+{
+  OSX1500:dyld_GradedArchs_checksOSBinary
+  Memcheck:Value8
+  fun:_ZNK5dyld311GradedArchs14checksOSBinaryEv
+  ...
+  fun:_ZN5dyld412RuntimeState21loadInsertedLibrariesERN5dyld317OverflowSafeArrayIPNS_6LoaderELy4294967295EEEPKS3_
+  ...
+}
+
+{
+  OSX1500:dyld_MachOFile_compatibleSlice
+  Memcheck:Value8
+  fun:_ZN5dyld39MachOFile15compatibleSliceER11DiagnosticsRyS3_PKvmPKcN6mach_o8PlatformEbRKNS_11GradedArchsEb
+  ...
+  fun:_ZN5dyld412RuntimeState21loadInsertedLibrariesERN5dyld317OverflowSafeArrayIPNS_6LoaderELy4294967295EEEPKS3_
+  ...
+}
+
+{
+  OSX1500:dyld_mach_msg
+  Memcheck:Param
+  mach_msg2(msg)
+  fun:mach_msg2_trap
+  ...
+  fun:_ZNK5dyld313MachOAnalyzer18forEachInitializerER11DiagnosticsRKNS0_15VMAddrConverterEU13block_pointerFvjEPKv
+  ...
+}
+
 # Happens during a fork
 
 {


### PR DESCRIPTION
While [migrating](https://github.com/bitcoin-core/secp256k1/pull/1759) this [project](https://github.com/bitcoin-core/secp256k1) CI framework to macOS 15, a few more suppressions appear to be needed.