### PR TITLE
Avoid Xcode 15+ ld assertion failure on macOS 14

### DIFF
--- a/coregrind/link_tool_exe_darwin.in
+++ b/coregrind/link_tool_exe_darwin.in
@@ -163,7 +163,7 @@ if ($archstr eq "arm64") {
 
 # Xcode 16 is completely borked and crashes when you use -segaddr so we rollback to
 # the old linker in the meantime
-if (@DARWIN_VERS@ >= 150000) {
+if (@DARWIN_VERS@ >= 140000) {
     $cmd = "$cmd -ld_classic";
 
 # If we're building with clang (viz, the C compiler as specified


### PR DESCRIPTION
Fixes https://github.com/LouisBrunner/valgrind-macos/issues/172