### PR TITLE
fix(macos): wrong DARWIN_VERS macro

### DIFF
--- a/coregrind/m_mach/mach_traps-arm64-darwin.S
+++ b/coregrind/m_mach/mach_traps-arm64-darwin.S
@@ -57,7 +57,7 @@ _mach_msg_trap:
 	svc 0x80
 	ret
 
-#if DARWIN_VERS >= DARWIN_13
+#if DARWIN_VERS >= DARWIN_13_00
 	// mach_msg_return_t mach_msg2_trap(...)
 	.text
 	.align 4

--- a/include/valgrind.h.in
+++ b/include/valgrind.h.in
@@ -789,8 +789,10 @@ typedef
    OrigFn;
 
 #define __SPECIAL_INSTRUCTION_PREAMBLE                            \
-            "ror x12, x12, #3  ;  ror x12, x12, #13 \n\t"         \
-            "ror x12, x12, #51 ;  ror x12, x12, #61 \n\t"
+            "ror x12, x12, #3  \n\t"                              \
+            "ror x12, x12, #13 \n\t"                              \
+            "ror x12, x12, #51 \n\t"                              \
+            "ror x12, x12, #61 \n\t"
 
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                          \
         _zzq_default, _zzq_request,                               \

--- a/include/valgrind.h.in
+++ b/include/valgrind.h.in
@@ -789,10 +789,8 @@ typedef
    OrigFn;
 
 #define __SPECIAL_INSTRUCTION_PREAMBLE                            \
-            "ror x12, x12, #3  \n\t"                              \
-            "ror x12, x12, #13 \n\t"                              \
-            "ror x12, x12, #51 \n\t"                              \
-            "ror x12, x12, #61 \n\t"
+            "ror x12, x12, #3  ;  ror x12, x12, #13 \n\t"         \
+            "ror x12, x12, #51 ;  ror x12, x12, #61 \n\t"
 
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                          \
         _zzq_default, _zzq_request,                               \


### PR DESCRIPTION
Continuation of #70, flagged in https://github.com/LouisBrunner/valgrind-macos/issues/176