### PR TITLE
ARM macOS fix

### DIFF
--- a/VEX/priv/guest_arm64_helpers.c
+++ b/VEX/priv/guest_arm64_helpers.c
@@ -2344,7 +2344,7 @@ VexGuestLayout
 
           /* Describe any sections to be regarded by Memcheck as
              'always-defined'. */
-          .n_alwaysDefd = 9,
+          .n_alwaysDefd = 10,
 
           /* flags thunk: OP is always defd, whereas DEP1 and DEP2
              have to be tracked.  See detailed comment in gdefs.h on
@@ -2358,7 +2358,8 @@ VexGuestLayout
                  /* 5 */ ALWAYSDEFD(guest_CMLEN),
                  /* 6 */ ALWAYSDEFD(guest_NRADDR),
                  /* 7 */ ALWAYSDEFD(guest_SC_CLASS),
-                 /* 8 */ ALWAYSDEFD(guest_TPIDR_EL0)
+                 /* 8 */ ALWAYSDEFD(guest_TPIDR_EL0),
+                 /* 9 */ ALWAYSDEFD(guest_TPIDRRO_EL0)
                }
         };
 

--- a/VEX/priv/guest_arm64_toIR.c
+++ b/VEX/priv/guest_arm64_toIR.c
@@ -1146,6 +1146,7 @@ static IRExpr* narrowFrom64 ( IRType dstTy, IRExpr* e )
 #define OFFB_CC_NDEP  offsetof(VexGuestARM64State,guest_CC_NDEP)
 
 #define OFFB_TPIDR_EL0 offsetof(VexGuestARM64State,guest_TPIDR_EL0)
+#define OFFB_TPIDRRO_EL0 offsetof(VexGuestARM64State,guest_TPIDRRO_EL0)
 #define OFFB_NRADDR   offsetof(VexGuestARM64State,guest_NRADDR)
 
 #define OFFB_Q0       offsetof(VexGuestARM64State,guest_Q0)
@@ -8038,12 +8039,16 @@ Bool dis_ARM64_branch_etc(/*MB_OUT*/DisResult* dres, UInt insn,
        || (INSN(31,0) & 0xFFFFFFE0) == 0xD53BD060 /*MRS RO*/) {
       Bool toSys = INSN(21,21) == 0;
       UInt tt    = INSN(4,0);
-      Bool isRO  = INSN(21,21) == 1;
+      /* bit 5 of the encoding selects op2: 010 = TPIDR_EL0 (rw),
+         011 = TPIDRRO_EL0 (ro). bit 21 selects MSR vs MRS, NOT
+         the rw/ro register choice. */
+      Bool isRO  = INSN(5,5) == 1;
       if (toSys) {
          stmt( IRStmt_Put( OFFB_TPIDR_EL0, getIReg64orZR(tt)) );
          DIP("msr tpidr_el0, %s\n", nameIReg64orZR(tt));
       } else {
-         putIReg64orZR(tt, IRExpr_Get( OFFB_TPIDR_EL0, Ity_I64 ));
+         Int srcOff = isRO ? OFFB_TPIDRRO_EL0 : OFFB_TPIDR_EL0;
+         putIReg64orZR(tt, IRExpr_Get( srcOff, Ity_I64 ));
          if (isRO) {
             DIP("mrs %s, tpidrro_el0\n", nameIReg64orZR(tt));
          } else {

--- a/VEX/pub/libvex_guest_arm64.h
+++ b/VEX/pub/libvex_guest_arm64.h
@@ -84,8 +84,14 @@ typedef
       ULong guest_CC_DEP2;
       ULong guest_CC_NDEP;
 
-      /* User-space thread register? */
+      /* User-space thread register?
+         On Apple arm64 these are NOT aliases — the kernel manages
+         TPIDRRO_EL0 (set via __pthread_set_self) while userspace runtimes
+         may freely write TPIDR_EL0. libsystem_malloc reads both and gets
+         very different values. */
       ULong guest_TPIDR_EL0;
+      ULong guest_TPIDRRO_EL0;
+      ULong guest_pad1;   /* keep guest_Q0 16-byte aligned */
 
       /* FP/SIMD state */
       U128 guest_Q0;

--- a/VEX/switchback/switchback.c
+++ b/VEX/switchback/switchback.c
@@ -388,7 +388,8 @@ void switchback ( void )
   assert(offsetof(VexGuestARM64State, guest_X30) == 16 + 8*30);
   assert(offsetof(VexGuestARM64State, guest_SP)  == 16 + 8*31);
   assert(offsetof(VexGuestARM64State, guest_TPIDR_EL0) == 16 + 8*37);
-  assert(offsetof(VexGuestARM64State, guest_Q0)  == 16 + 8*38 + 16*0);
+  assert(offsetof(VexGuestARM64State, guest_TPIDRRO_EL0) == 16 + 8*38);
+  assert(offsetof(VexGuestARM64State, guest_Q0)  == 16 + 8*40 + 16*0);
 
   HWord arg0 = (HWord)&gst;
   HWord arg1 = LibVEX_GuestARM64_get_nzcv(&gst);

--- a/coregrind/m_initimg/initimg-darwin.c
+++ b/coregrind/m_initimg/initimg-darwin.c
@@ -866,6 +866,21 @@ void VG_(ii_finalise_image)( IIFinaliseImageInfo iifii )
    arch->vex.guest_XSP = iifii.initial_client_SP;
    arch->vex.guest_PC = iifii.initial_client_IP;
 
+   /* Seed the per-thread system registers from the host. The kernel set
+      TPIDRRO_EL0 to the main thread's pthread/thread-self pointer; libpthread
+      and libsystem_malloc both read it before our pthread_set_self syswrap
+      gets a chance to fire. TPIDR_EL0 is a small kernel-managed scratch on
+      Apple arm64 (it is NOT the TLS pointer the way Linux uses it); we still
+      seed it so reads early in dyld init see what the host had. */
+   {
+      ULong host_tpidr_el0 = 0;
+      ULong host_tpidrro_el0 = 0;
+      __asm__ __volatile__("mrs %0, tpidr_el0"   : "=r"(host_tpidr_el0));
+      __asm__ __volatile__("mrs %0, tpidrro_el0" : "=r"(host_tpidrro_el0));
+      arch->vex.guest_TPIDR_EL0   = host_tpidr_el0;
+      arch->vex.guest_TPIDRRO_EL0 = host_tpidrro_el0;
+   }
+
 #  else
 #    error Unknown platform
 #  endif

--- a/coregrind/m_initimg/initimg-darwin.c
+++ b/coregrind/m_initimg/initimg-darwin.c
@@ -393,9 +393,31 @@ static HChar *copy_str(HChar **tab, const HChar *str)
 
    ---------------------------------------------------------------- */
 
+/* Returns True if the host's apple[] entry must NOT be forwarded to the
+   client. Skipped keys are tied to the launcher binary's identity (a
+   different image with a different stack from the client) — Valgrind
+   emits its own values for these. */
+static Bool skip_apple_entry(const HChar* entry)
+{
+   static const struct { const HChar* p; SizeT len; } skip_keys[] = {
+      { "executable_path=",     16 },
+      { "executable_cdhash=",   18 },
+      { "executable_boothash=", 20 },
+      { "executable_file=",     16 },
+      { "arm64e_abi=",          11 },
+   };
+   UInt i;
+   for (i = 0; i < sizeof(skip_keys)/sizeof(skip_keys[0]); i++) {
+      if (VG_(strncmp)(entry, skip_keys[i].p, skip_keys[i].len) == 0)
+         return True;
+   }
+   return False;
+}
+
 static
 Addr setup_client_stack( void*  init_sp,
                          HChar** envp,
+                         HChar** host_apple,
                          const ExeInfo* info,
                          Addr   clstack_end,
                          SizeT  clstack_max_size,
@@ -470,6 +492,16 @@ Addr setup_client_stack( void*  init_sp,
    stringsize += VG_(strlen)(EXTRA_APPLE_ARG) + 1;
    auxsize += sizeof(Word);
 #endif
+
+   /* Forward most of the host's apple[] block to the client so dyld and
+      libsystem_malloc see real per-process tokens (malloc_entropy, ptr_munge,
+      stack_guard, ...). Without these, the xzone allocator reads zero/garbage
+      and crashes during dyld init for tools that don't redirect malloc. */
+   for (cpp = host_apple; cpp && *cpp; cpp++) {
+      if (skip_apple_entry(*cpp)) continue;
+      stringsize += VG_(strlen)(*cpp) + 1;
+      auxsize += sizeof(Word);
+   }
 
    /* Darwin mach_header */
    if (info->dynamic)
@@ -575,6 +607,12 @@ Addr setup_client_stack( void*  init_sp,
 #if defined(VGA_arm64)
    *ptr++ = (Addr)copy_str(&strtab, EXTRA_APPLE_ARG);
 #endif
+
+   /* Forward filtered host apple[] entries (must match the sizing pass above). */
+   for (cpp = host_apple; cpp && *cpp; cpp++) {
+      if (skip_apple_entry(*cpp)) continue;
+      *ptr++ = (Addr)copy_str(&strtab, *cpp);
+   }
 
    *ptr++ = 0;
 
@@ -733,10 +771,18 @@ IIFinaliseImageInfo VG_(ii_create_image)( IICreateImageInfo iicii,
    iicii.clstack_end = info.stack_end;
    iifii.clstack_max_size = info.stack_end - info.stack_start + 1;
 
-   iifii.initial_client_SP =
-       setup_client_stack( iicii.argv - 1, env, &info,
-                           iicii.clstack_end, iifii.clstack_max_size,
-                           vex_archinfo );
+   /* Locate host's apple[] block: it sits immediately after envp's NULL. */
+   {
+      HChar** cpp;
+      HChar** host_apple = NULL;
+      for (cpp = iicii.envp; cpp && *cpp; cpp++) ;
+      if (cpp) host_apple = cpp + 1;
+
+      iifii.initial_client_SP =
+          setup_client_stack( iicii.argv - 1, env, host_apple, &info,
+                              iicii.clstack_end, iifii.clstack_max_size,
+                              vex_archinfo );
+   }
    iifii.dynamic = info.dynamic;
 
    VG_(free)(env);

--- a/coregrind/m_syswrap/syswrap-arm64-darwin.c
+++ b/coregrind/m_syswrap/syswrap-arm64-darwin.c
@@ -409,7 +409,7 @@ void pthread_hijack(Addr self, Addr kport, Addr func, Addr func_arg, Addr stacks
    vex->guest_X4 = stacksize;
    vex->guest_X5 = flags;
    vex->guest_XSP = sp;
-   vex->guest_TPIDR_EL0 = self + pthread_tsd_offset;
+   vex->guest_TPIDRRO_EL0 = self + pthread_tsd_offset;
 
    // Record thread's stack and Mach port and pthread struct
    tst->os_state.pthread = self;
@@ -549,7 +549,7 @@ void wqthread_hijack(Addr self, Addr kport, Addr stackaddr, Addr kevent_list,
    vex->guest_X4 = upcall_flags;
    vex->guest_X5 = kevent_count;
    vex->guest_XSP = sp;
-   vex->guest_TPIDR_EL0 = self + pthread_tsd_offset;
+   vex->guest_TPIDRRO_EL0 = self + pthread_tsd_offset;
 
    stacksize = 512*1024;  // wq stacks are always DEFAULT_STACK_SIZE
    stack = VG_PGROUNDUP(sp) - stacksize;

--- a/coregrind/m_syswrap/syswrap-darwin.c
+++ b/coregrind/m_syswrap/syswrap-darwin.c
@@ -10031,7 +10031,7 @@ PRE(thread_set_tsd_base)
   {
     ThreadState *tst = VG_(get_ThreadState)(tid);
     tst->os_state.pthread = ARG1;
-    tst->arch.vex.guest_TPIDR_EL0 = ARG1;
+    tst->arch.vex.guest_TPIDRRO_EL0 = ARG1;
     // SET_STATUS_Success(0x60);
     // see comments on x86 case just below
     SET_STATUS_from_SysRes(


### PR DESCRIPTION
Fixes #169.

Claude's analysis follows. This does fix the problem.

There have been other fixes since I first opened the issue that have contributed to a solution as well, from at least @VisualEhrmanntraut. Much appreciated :)

---

Two fixes, both required to get callgrind/cachegrind/none working past dyld init on macOS 26 (Tahoe) arm64. Memcheck/helgrind/massif/drd/dhat masked both bugs by redirecting `malloc`, so libobjc's first allocation never reached `libsystem_malloc`'s xzone allocator.

### 1. Forward the host apple[] block to the client

Tahoe's libsystem_malloc seeds its `malloc_entropy[]` from the apple vector entries the kernel hands to dyld (`malloc_entropy=…`, `ptr_munge=…`, `stack_guard=…`, `main_stack=…`, etc.). Without those, the entropy array stays at the zero-init pattern and downstream code that relies on it (xzone magazine selection, scribble fill, …) goes into undefined territory.

`coregrind/m_initimg/initimg-darwin.c` now walks past the host's `envp` NULL terminator to find the host apple block, then forwards every entry through to the client except a small skiplist that's tied to the launcher binary's identity (`executable_path`, `executable_cdhash`, `executable_boothash`, `executable_file`, `arm64e_abi`) — Valgrind emits its own values for those.

### 2. Stop aliasing TPIDR_EL0 and TPIDRRO_EL0

VEX kept a single `guest_TPIDR_EL0` field and routed both `mrs xN, TPIDR_EL0` and `mrs xN, TPIDRRO_EL0` reads through it. On real arm64 these are separate registers, and on Apple userspace they hold very different values:

- `tpidr_el0` is a small kernel-managed scratch (e.g. `0x00..0x03`)
- `tpidrro_el0` is the per-thread pointer the kernel set during thread setup (a real pointer like `0x1f7…`)

`__pthread_set_self` actually writes `TPIDRRO_EL0` on hardware, but the Darwin syswrap was writing `guest_TPIDR_EL0`. After libpthread bootstrap ran, the guest's `mrs xN, TPIDR_EL0` returned a giant pointer instead of a small int. libsystem_malloc's xzone uses `(TPIDR_EL0 >> 12) & 0xff` as part of a magazine-index hash; the bogus pointer pushed the index from the valid 0..14 range to ~152, walking off the end of the 15-entry sub-zone array and dereferencing uninit memory inside main_zone. The crash always landed at `_xzm_segment_group_alloc_segment+144` doing `ldrb w9, [x8, #0x178]` with `x8 = NULL`.

Changes:

- `VEX/pub/libvex_guest_arm64.h` — add `guest_TPIDRRO_EL0` (plus a `guest_pad1` so `guest_Q0` stays 16-byte aligned).
- `VEX/priv/guest_arm64_toIR.c` — add `OFFB_TPIDRRO_EL0` and route MRS reads of TPIDRRO_EL0 there. The dispatcher now distinguishes `MRS TPIDR_EL0` from `MRS TPIDRRO_EL0` by op2 (bit 5 of the encoding), not by the L bit (bit 21) which only distinguishes MSR vs. MRS.
- `VEX/priv/guest_arm64_helpers.c` — mark `guest_TPIDRRO_EL0` as always-defined for memcheck.
- `VEX/switchback/switchback.c` — update the `guest_Q0` offset assertion.
- `coregrind/m_syswrap/syswrap-darwin.c` — `__pthread_set_self` (`thread_set_tsd_base`) now writes `guest_TPIDRRO_EL0`.
- `coregrind/m_syswrap/syswrap-arm64-darwin.c` — `bsdthread_create` and `wqthread_hijack` set `guest_TPIDRRO_EL0` for new threads.
- `coregrind/m_initimg/initimg-darwin.c` — seed the main thread's `guest_TPIDR_EL0` and `guest_TPIDRRO_EL0` from the host's actual values via inline `mrs`, so dyld init reads sensible values before any syscall has fired.

## Verification

`cg_test` (a tiny reproducer that does one `printf`) goes from 0/50 to 20/20 successful runs under `--tool=none`, `--tool=callgrind`, and `--tool=cachegrind`. `--tool=memcheck` continues to pass (10/10) — no regression.

Smoke-tested end-to-end with [gungraun][gungraun]: all 24 of its default_tool benchmarks (covering callgrind, cachegrind, dhat, memcheck, helgrind, drd, massif, bbv) run to completion against this build.

[gungraun]: https://github.com/gungraun/gungraun