### PR TITLE
Cleanup and add MRS APGAKEYLO_EL1

### DIFF
--- a/VEX/priv/guest_arm64_toIR.c
+++ b/VEX/priv/guest_arm64_toIR.c
@@ -8372,6 +8372,16 @@ Bool dis_ARM64_branch_etc(/*MB_OUT*/DisResult* dres, UInt insn,
       return True;
    }
 
+   /* ---- Case for MRS APGAKEYLO_EL1 ----
+      Pointer Authentication Generic A Key
+      D5 1B 42 A0
+    */
+   if ((INSN(31, 0) & 0xFFFFFFE0) == 0xD51B42A0) {
+      UInt     tt   = INSN(4,0);
+      DIP("mrs %s, apgakeyl0_el1 (ignored)\n", nameIReg64orZR(tt));
+      return True;
+   }
+
    /* ------------------ ISB, DMB, DSB ------------------ */
    /* 31          21            11  7 6  4
       11010 10100 0 00 011 0011 CRm 1 01 11111  DMB opt

--- a/coregrind/m_stacktrace.c
+++ b/coregrind/m_stacktrace.c
@@ -1267,7 +1267,7 @@ UInt VG_(get_StackTrace_wrk) ( ThreadId tid_if_known,
    ips[0] = uregs.pc;
    i = 1;
 
-#  if defined(VGO_darwin) || (defined(VGO_freebsd) && (FREEBSD_VERS < FREEBSD_13_0))
+#  if defined(VGO_darwin)
    if (VG_(is_valid_tid)(tid_if_known) &&
       VG_(is_in_syscall)(tid_if_known) &&
       i < max_n_ips) {
@@ -1284,7 +1284,6 @@ UInt VG_(get_StackTrace_wrk) ( ThreadId tid_if_known,
       if (fps) fps[i] = uregs.x29;
       i++;
    }
-#  endif
 
    /* If we are recording a stack trace, we most likely failed,
     * this will usually happen inside a syscall/platform func,
@@ -1293,7 +1292,6 @@ UInt VG_(get_StackTrace_wrk) ( ThreadId tid_if_known,
     * So it's messy but the easiest way to get a somewhat sane stack trace is to force x30 in there.
     * This will probably create a lot of false positives but isn't that better that no stack trace at all?
     */
-#  if defined(VGO_darwin)
    if (uregs.x30 != 0 && uregs.x30 != uregs.pc && i < max_n_ips
       && fp_min <= uregs.x29 && uregs.x29 <= fp_max - 1 * sizeof(UWord)
       && ML_(safe_to_deref)((void*)uregs.x29, 2*sizeof(UWord))
@@ -1338,6 +1336,7 @@ UInt VG_(get_StackTrace_wrk) ( ThreadId tid_if_known,
          continue;
       }
 
+#if defined(VGO_darwin)
       /* See amd64 version for details. */
       if (fp_min <= uregs.x29 && uregs.x29 <= fp_max - 1 * sizeof(UWord)
           && ML_(safe_to_deref)((void*)uregs.x29, 2*sizeof(UWord))) {
@@ -1363,6 +1362,7 @@ UInt VG_(get_StackTrace_wrk) ( ThreadId tid_if_known,
          RECURSIVE_MERGE(cmrf,ips,i);
          continue;
       }
+#endif
 
       /* No luck.  We have to give up. */
       break;

--- a/coregrind/m_syswrap/priv_syswrap-darwin.h
+++ b/coregrind/m_syswrap/priv_syswrap-darwin.h
@@ -48,9 +48,6 @@ Bool ML_(sync_mappings)(const HChar *when, const HChar *where, UWord num);
 // NYI = wrapper not yet implemented in Valgrind
 // NOC = the non-"_nocancel" wrapper is used
 // old = the syscall no longer exists in Darwin
-#if defined(VGA_arm64)
-DECL_TEMPLATE(darwin, syscall);                 // 0
-#endif
 DECL_TEMPLATE(darwin, exit);                    // 1
 // GEN fork 2
 // GEN read 3
@@ -816,7 +813,6 @@ DECL_TEMPLATE(darwin, semaphore_wait);
 DECL_TEMPLATE(darwin, semaphore_wait_signal);
 DECL_TEMPLATE(darwin, semaphore_timedwait);
 DECL_TEMPLATE(darwin, semaphore_timedwait_signal);
-DECL_TEMPLATE(darwin, task_name_for_pid);
 DECL_TEMPLATE(darwin, task_for_pid);
 DECL_TEMPLATE(darwin, task_name_for_pid);
 DECL_TEMPLATE(darwin, pid_for_task);

--- a/coregrind/m_syswrap/syswrap-darwin.c
+++ b/coregrind/m_syswrap/syswrap-darwin.c
@@ -3600,10 +3600,6 @@ static void scan_attrlist(ThreadId tid, struct vki_attrlist *attrList,
       { ATTR_VOL_QUOTA_SIZE,      sizeof(off_t) },
       { ATTR_VOL_RESERVED_SIZE,   sizeof(off_t) },
 #endif
-#if DARWIN_VERS >= DARWIN_10_15
-      { ATTR_VOL_QUOTA_SIZE,      sizeof(off_t) },
-      { ATTR_VOL_RESERVED_SIZE,   sizeof(off_t) },
-#endif
       { ATTR_VOL_ATTRIBUTES,      sizeof(vol_attributes_attr_t) },
       { 0,                        0 }
    };

--- a/coregrind/pub_core_trampoline.h
+++ b/coregrind/pub_core_trampoline.h
@@ -68,10 +68,6 @@ extern void VG_(amd64_freebsd_SUBST_FOR_sigreturn)(void);
 extern void VG_(arm64_freebsd_SUBST_FOR_sigreturn);
 #endif
 
-#if defined(VGP_arm64_freebsd)
-extern void VG_(arm64_freebsd_SUBST_FOR_sigreturn);
-#endif
-
 #if defined(VGP_x86_linux)
 extern Addr VG_(x86_linux_SUBST_FOR_sigreturn);
 extern Addr VG_(x86_linux_SUBST_FOR_rt_sigreturn);

--- a/include/vki/vki-scnums-darwin.h
+++ b/include/vki/vki-scnums-darwin.h
@@ -204,7 +204,7 @@
 #define __NR_task_for_pid                     VG_DARWIN_SYSCALL_CONSTRUCT_MACH(45)
 #define __NR_pid_for_task                     VG_DARWIN_SYSCALL_CONSTRUCT_MACH(46)
 
-#if DARWIN_VERS >= DARWIN_12_00
+#if DARWIN_VERS >= DARWIN_13_00
 #define __NR_mach_msg2_trap                   VG_DARWIN_SYSCALL_CONSTRUCT_MACH(47)
 #endif
 

--- a/include/vki/vki-scnums-darwin.h
+++ b/include/vki/vki-scnums-darwin.h
@@ -204,7 +204,7 @@
 #define __NR_task_for_pid                     VG_DARWIN_SYSCALL_CONSTRUCT_MACH(45)
 #define __NR_pid_for_task                     VG_DARWIN_SYSCALL_CONSTRUCT_MACH(46)
 
-#if DARWIN_VERS >= DARWIN_13_00
+#if DARWIN_VERS >= DARWIN_12_00
 #define __NR_mach_msg2_trap                   VG_DARWIN_SYSCALL_CONSTRUCT_MACH(47)
 #endif
 


### PR DESCRIPTION
I get SIGILL in my macOS 13 arm64 VM due to MRS APGAKEYLO_EL1. For the moment this is just ignored. A dirty helper probably won't work because this is protected. It might be better to set the register to 0.

The stacktrace changes isolate the macOS only parts. On FreeBSD I think that the CFI handling improved so the syscall adjustment is no longer needed. FreeBSD was first ported to arm64 with version 13 so the syscall adjustment for versions 12 and earlier was never needed.

priv_syswrap-darwin.h syscall 0 is handled in syswrap-mainc.c. Double declaration of task_name_for_pid.

syswrap-darwin.c duplicates of ATTR_VOL_QUOTA_SIZE and ATTR_VOL_RESERVED_SIZE.

pub_core_trampoline.h duplicate of VG_(arm64_freebsd_SUBST_FOR_sigreturn)

vki-scnums-darwin.h make __NR_mach_msg2_trap visible on macOS 12.

Most of those are superficial. The VEX change is more important.