### PR TITLE
Darwin: Define CPU_TYPE_ARM64 if needed

### DIFF
--- a/coregrind/launcher-darwin.c
+++ b/coregrind/launcher-darwin.c
@@ -53,6 +53,11 @@
 #include "pub_core_ume.h"
 #include "pub_core_mach.h"
 
+/* Prior to OS X 10.10, CPU_TYPE_ARM64 is not defined in the system headers */
+#ifndef CPU_TYPE_ARM64
+#define CPU_TYPE_ARM64  (CPU_TYPE_ARM | CPU_ARCH_ABI64)
+#endif
+
 static struct {
    cpu_type_t cputype;
    const char *apple_name;     // e.g. x86_64


### PR DESCRIPTION
CPU_TYPE_ARM64 was not defined prior to OS X 10.10, which resulted in compilation failure.  Even if an executable cannot be run, the macro definition allows its architecture to be accurately displayed in messages.

The compilation failure was observed on the MacPorts buildbot, which attempts a separate build for each macOS version and architecutre.  The failed build log from the MacPorts OS X 10.9 builder is at: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/341004/steps/install-port/logs/stdio