### PR TITLE
fix(macos): avoid assert on functions relying on kernelrpc_mach_port_construct_trap (e.g. CFMachPortCreate)

### DIFF
--- a/coregrind/m_syswrap/syswrap-darwin.c
+++ b/coregrind/m_syswrap/syswrap-darwin.c
@@ -10656,6 +10656,7 @@ POST(kernelrpc_mach_port_construct_trap)
    PRINT("-> name:%p", *(mach_port_name_t**)a4);
    if (ML_(safe_to_deref)((mach_port_name_t*)a4, sizeof(mach_port_name_t*))) {
       POST_MEM_WRITE(a4, sizeof(mach_port_name_t*));
+      record_unnamed_port(tid, *(mach_port_name_t*)a4, MACH_PORT_RIGHT_RECEIVE);
    }
 }
 


### PR DESCRIPTION
Resolves #189

@paulfloyd Any thoughts on this?